### PR TITLE
Clean up update scripts

### DIFF
--- a/.github/update.py
+++ b/.github/update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#! /usr/bin/env python3
 # Note: this wont work on python 2.7
 # This script must be executed at the root of the repository.
 
@@ -8,62 +8,61 @@ import shutil
 import html
 from xml.sax import saxutils as su
 
-ET.register_namespace('', "urn:oasis:names:tc:xliff:document:1.2")
-ET.register_namespace('qt', "urn:trolltech:names:ts:document:1.0")
+ET.register_namespace('', 'urn:oasis:names:tc:xliff:document:1.2')
+ET.register_namespace('qt', 'urn:trolltech:names:ts:document:1.0')
 
-VPN_PROJECT_DIR ="vpn/" 
-OUT_PROJECT_DIR ="translationFiles/"
+VPN_PROJECT_DIR = 'vpn'
+OUT_PROJECT_DIR = 'translationFiles'
 
-#LCONVERT = "/usr/lib/qt5/bin/lconvert"
-
-LCONVERT = "lconvert"
+#LCONVERT = '/usr/lib/qt5/bin/lconvert'
+LCONVERT = 'lconvert'
 
 # Make sure the Target ts files are up to date
-os.system(f'lupdate {VPN_PROJECT_DIR}src/src.pro -ts')
+srcFile = os.path.join(VPN_PROJECT_DIR, 'src', 'src.pro')
+os.system(f'lupdate {srcFile} -ts')
 
-for fileName in os.listdir(f'{VPN_PROJECT_DIR}/translations/'):
-    if(not fileName.endswith(".ts")):
+for fileName in os.listdir(os.path.join(VPN_PROJECT_DIR, 'translations')):
+    if (not fileName.endswith('.ts')):
         continue
-    filePath = f'{VPN_PROJECT_DIR}/translations/{fileName}'
-    # Usual filename -> mozillavpn_zh-cn.ts
-    language = fileName.split("_")[1].split(".")[0] # de , zh-cn ...
-    basename = fileName.split("_")[0] # mozillavpn
-    outPath = f'{OUT_PROJECT_DIR}/{language}'
-    # Create folder for each language and convert 
-    # ts file to /{lang}/mozillavpn.xlf
-    print(f"Checking {language}")
+    filePath = os.path.join(VPN_PROJECT_DIR, 'translations', fileName)
+    # Usual filename: mozillavpn_zh-cn.ts
+    locale = fileName.split('_')[1].split('.')[0] # de, zh-cn, etc.
+    baseName = fileName.split('_')[0] # mozillavpn
+    outPath = os.path.join(OUT_PROJECT_DIR, locale)
+    # Create folder for each locale and convert
+    # ts file to /{locale}/mozillavpn.xlf
+    print(f'Checking {locale}')
     if not os.path.exists(outPath):
         os.mkdir(outPath)
-    
-    if not os.path.exists(f'{outPath}/{basename}.xlf'):
-        # If the not file exsists
-        print(f"Creating {outPath}/{basename}")
-        os.system(f'{LCONVERT} -i {filePath} -o {outPath}/{basename}.xlf')
-    else:
-        # keep its current translations
-        print(f"Updating {outPath}/{basename}")
-        os.system(f'{LCONVERT} -i {filePath} -i {outPath}/{basename}.xlf -o {outPath}/{basename}.xlf')
 
-    outFile = f'{outPath}/{basename}.xlf'
-    ## Now Clean the new xlf a bit up
-    tree = ET.parse(f'{outPath}/{basename}.xlf')
+    outFile = os.path.join(outPath, f'{baseName}.xlf')
+    if not os.path.exists(outFile):
+        # If the file doesn't exist
+        print(f'Creating {outFile}')
+        os.system(f'{LCONVERT} -i {filePath} -o {outFile}')
+    else:
+        # Keep current translations
+        print(f'Updating {outFile}')
+        os.system(f'{LCONVERT} -i {filePath} -i {outFile} -o {outFile}')
+
+    # Now clean up the new xliff file
+    tree = ET.parse(outFile)
     root = tree.getroot()
 
-    #Iterate all targetElements and remove empty ones
-    for element in root.iter("{urn:oasis:names:tc:xliff:document:1.2}trans-unit"):
-        target = element.find("{urn:oasis:names:tc:xliff:document:1.2}target")
-        if(not target.text):
+    # Iterate all targetElements and remove empty ones
+    for element in root.iter('{urn:oasis:names:tc:xliff:document:1.2}trans-unit'):
+        target = element.find('{urn:oasis:names:tc:xliff:document:1.2}target')
+        if (not target.text):
             element.remove(target)
 
-#    #Unescape any html in text
-#    for element in root.iter("{urn:oasis:names:tc:xliff:document:1.2}source"):
+#    # Unescape any html in text
+#    for element in root.iter('{urn:oasis:names:tc:xliff:document:1.2}source'):
 #        t = element.text
 #        element.clear()
 #        element.tail = su.unescape(t)
 #        #print(f'Unescaped : {element.text}')
 
-    #Iterate all targetElements and remove empty ones
-    for element in root.iter("{urn:oasis:names:tc:xliff:document:1.2}extracomment"):
-        element.tag="note"
-    tree.write(f'{outPath}/{basename}.xlf')
-
+    # Iterate all targetElements and remove empty ones
+    for element in root.iter('{urn:oasis:names:tc:xliff:document:1.2}extracomment'):
+        element.tag = 'note'
+    tree.write(outFile)

--- a/.github/update.py
+++ b/.github/update.py
@@ -30,12 +30,12 @@ for fileName in os.listdir(os.path.join(VPN_PROJECT_DIR, 'translations')):
     baseName = fileName.split('_')[0] # mozillavpn
     outPath = os.path.join(OUT_PROJECT_DIR, locale)
     # Create folder for each locale and convert
-    # ts file to /{locale}/mozillavpn.xlf
+    # ts file to /{locale}/mozillavpn.xliff
     print(f'Checking {locale}')
     if not os.path.exists(outPath):
         os.mkdir(outPath)
 
-    outFile = os.path.join(outPath, f'{baseName}.xlf')
+    outFile = os.path.join(outPath, f'{baseName}.xliff')
     if not os.path.exists(outFile):
         # If the file doesn't exist
         print(f'Creating {outFile}')

--- a/.github/update.sh
+++ b/.github/update.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# Updates QT Translation sources, converts them into xlf
+# Updates QT Translation sources, converts them into XLIFF
 # Usage ./import.sh /path/to/mozVPN/ /path/to/translateGit
 #
 # lupdate & lconvert with qml support must be available
@@ -11,12 +11,12 @@ LCONVERT=$(which lconvert)
 LUPDATE vpn/src/src.pro -ts
 
 for FILE in $1/translations/*; do
-if [ -f "$2/$(basename '$FILE' .ts).xliff" ]; then
-    echo "Updating $2/$(basename '$FILE' .ts).xliff"
-    LCONVERT -i "$FILE" -i $2/"$(basename "$FILE" .ts)".xliff -o $2/"$(basename "$FILE" .ts)".xliff
-else
-    echo "Importing $2/$(basename '$FILE' .ts).xliff"
-    LCONVERT -i "$FILE" -o $2/"$(basename "$FILE" .ts)".xliff
-fi
-
+    OUT_FILE="$2/$(basename '$FILE' .ts).xliff"
+    if [ -f $OUT_FILE ]; then
+        echo "Updating $OUT_FILE"
+        LCONVERT -i "$FILE" -i $OUT_FILE -o $OUT_FILE
+    else
+        echo "Importing $OUT_FILE"
+        LCONVERT -i "$FILE" -o $OUT_FILE
+    fi
 done

--- a/.github/update.sh
+++ b/.github/update.sh
@@ -1,20 +1,22 @@
-#!/usr/bin/bash
+#! /usr/bin/env bash
 
 # Updates QT Translation sources, converts them into xlf
 # Usage ./import.sh /path/to/mozVPN/ /path/to/translateGit
-# 
+#
 # lupdate & lconvert with qml support must be available
 
+LUPDATE=$(which lupdate)
+LCONVERT=$(which lconvert)
 
-/usr/lib/qt5/bin/lupdate vpn/src/src.pro -ts
+LUPDATE vpn/src/src.pro -ts
 
-for FILE in $1/translations/*; do 
+for FILE in $1/translations/*; do
 if [ -f "$2/$(basename '$FILE' .ts).xlf" ]; then
-    echo "Updateing $2/$(basename '$FILE' .ts).xlf"
-    /usr/lib/qt5/bin/lconvert -i "$FILE" -i $2/"$(basename "$FILE" .ts)".xlf -o $2/"$(basename "$FILE" .ts)".xlf
-else 
+    echo "Updating $2/$(basename '$FILE' .ts).xlf"
+    LCONVERT -i "$FILE" -i $2/"$(basename "$FILE" .ts)".xlf -o $2/"$(basename "$FILE" .ts)".xlf
+else
     echo "Importing $2/$(basename '$FILE' .ts).xlf"
-    /usr/lib/qt5/bin/lconvert -i "$FILE" -o $2/"$(basename "$FILE" .ts)".xlf
+    LCONVERT -i "$FILE" -o $2/"$(basename "$FILE" .ts)".xlf
 fi
 
 done

--- a/.github/update.sh
+++ b/.github/update.sh
@@ -11,12 +11,12 @@ LCONVERT=$(which lconvert)
 LUPDATE vpn/src/src.pro -ts
 
 for FILE in $1/translations/*; do
-if [ -f "$2/$(basename '$FILE' .ts).xlf" ]; then
-    echo "Updating $2/$(basename '$FILE' .ts).xlf"
-    LCONVERT -i "$FILE" -i $2/"$(basename "$FILE" .ts)".xlf -o $2/"$(basename "$FILE" .ts)".xlf
+if [ -f "$2/$(basename '$FILE' .ts).xliff" ]; then
+    echo "Updating $2/$(basename '$FILE' .ts).xliff"
+    LCONVERT -i "$FILE" -i $2/"$(basename "$FILE" .ts)".xliff -o $2/"$(basename "$FILE" .ts)".xliff
 else
-    echo "Importing $2/$(basename '$FILE' .ts).xlf"
-    LCONVERT -i "$FILE" -o $2/"$(basename "$FILE" .ts)".xlf
+    echo "Importing $2/$(basename '$FILE' .ts).xliff"
+    LCONVERT -i "$FILE" -o $2/"$(basename "$FILE" .ts)".xliff
 fi
 
 done


### PR DESCRIPTION
Python
- Use os.path instead of hardcoding OS specific separators
- Coding consistency
- Use '.xliff' instead of '.xlf'

Bash
- Don't hardcode path to executables