### PR TITLE
Update README, add CODEOWNER and CoC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# flod as main contact for string changes
+en/*.xliff @flodolo

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Community Participation Guidelines
+
+This repository is governed by Mozilla's code of conduct and etiquette guidelines.
+
+For more details, please read the
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
+
+## How to Report
+
+For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/)' page.
+
+<!--
+## Project Specific Etiquette
+
+In some cases, there will be additional project etiquette i.e.: (https://bugzilla.mozilla.org/page.cgi?id=etiquette.html).
+Please update for your project.
+-->

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
-# VPN translations 
+# Mozilla VPN localization
 
-Translation files go here, check PR as new strings come in :) 
+Localization for the Mozilla VPN project.
+
+## License
+
+Translations in this repository are available under the terms of the [Mozilla Public License v2.0](http://www.mozilla.org/MPL/2.0/).


### PR DESCRIPTION
This matches the structure of existing repositories. Not putting a link to the code repositories, since it's still private at the moment.