### PR TITLE
Add missing strings to Italian

### DIFF
--- a/it/mozillavpn.xliff
+++ b/it/mozillavpn.xliff
@@ -1,17 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file datatype="plaintext" original="../src/ui/components/VPNAboutUs.qml" source-language="en" target-language="it">
+    <body>
+      <trans-unit id="vpn.aboutUs.tos">
+        <source xml:space="preserve">Terms of Service</source>
+      </trans-unit>
+      <trans-unit id="vpn.aboutUs.privacyPolicy">
+        <source xml:space="preserve">Privacy Policy</source>
+      </trans-unit>
+      <trans-unit id="vpn.settings.aboutUs">
+        <source xml:space="preserve">About us</source>
+      </trans-unit>
+      <trans-unit id="vpn.main.productName">
+        <source xml:space="preserve">Mozilla VPN</source>
+      </trans-unit>
+      <trans-unit id="vpn.main.productDescription">
+        <source xml:space="preserve">A fast, secure and easy to use VPN. Built by the makers of Firefox.</source>
+      </trans-unit>
+      <trans-unit id="vpn.aboutUs.releaseVersion">
+        <source xml:space="preserve">Release Version</source>
+        <note annotates="source" from="developer">Refers to the installed version; Example - "Release Version: 1.23"</note>
+      </trans-unit>
+    </body>
+  </file>
   <file datatype="plaintext" original="../src/ui/components/VPNCheckBoxAlert.qml" source-language="en" target-language="it">
     <body>
       <trans-unit id="vpn.turnOffAlert.enabling">
         <source xml:space="preserve">VPN must be off before enabling</source>
         <target xml:space="preserve">La VPN deve essere disattivata per attivare questa impostazione</target>
-        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
         <note annotates="source" from="developer">This is a Setting which requires the VPN to be disconnected to change state</note>
       </trans-unit>
       <trans-unit id="vpn.turnOffAlert.disabling">
         <source xml:space="preserve">VPN must be off before disabling</source>
         <target xml:space="preserve">La VPN deve essere disattivata per disattivare questa impostazione</target>
-        <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
         <note annotates="source" from="developer">This is a Setting which requires the VPN to be disconnected to change state</note>
       </trans-unit>
     </body>
@@ -21,25 +42,21 @@
       <trans-unit id="vpn.connectionInfo.ip">
         <source xml:space="preserve">IP: %1</source>
         <target xml:space="preserve">IP: %1</target>
-        <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
-        <note annotates="source" from="developer">The Current Ip adress</note>
+        <note annotates="source" from="developer">The current IP address</note>
       </trans-unit>
       <trans-unit id="vpn.connectionInfo.download">
         <source xml:space="preserve">Download</source>
-        <target>Download</target>
-        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
-        <note annotates="source" from="developer">the current download speed. The speed is shown at the next line.</note>
+        <target xml:space="preserve">Download</target>
+        <note annotates="source" from="developer">The current download speed. The speed is shown on the next line.</note>
       </trans-unit>
       <trans-unit id="vpn.connectionInfo.upload">
         <source xml:space="preserve">Upload</source>
-        <target>Upload</target>
-        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
-        <note annotates="source" from="developer">the current upload speed</note>
+        <target xml:space="preserve">Upload</target>
+        <note annotates="source" from="developer">The current upload speed. The speed is shown on the next line.</note>
       </trans-unit>
       <trans-unit id="vpn.connectionInfo.close">
         <source xml:space="preserve">Close</source>
         <target xml:space="preserve">Chiudi</target>
-        <context-group purpose="location"><context context-type="linenumber">156</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -48,7 +65,6 @@
       <trans-unit id="vpn.connectionStability.checkConnection">
         <source xml:space="preserve">Check Connection</source>
         <target xml:space="preserve">Verifica connessione</target>
-        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -57,17 +73,11 @@
       <trans-unit id="vpn.devices.myDevices">
         <source xml:space="preserve">My devices</source>
         <target xml:space="preserve">I miei dispositivi</target>
-        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/views/ViewDevices.qml</context><context context-type="linenumber">42</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.devices.activeVsMaxDeviceCount">
         <source xml:space="preserve">%1 of %2</source>
         <target xml:space="preserve">%1 di %2</target>
-        <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/views/ViewDevices.qml</context><context context-type="linenumber">23</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/views/ViewDevices.qml</context><context context-type="linenumber">32</context></context-group>
-        <note annotates="source" from="developer">Context: You have "x of y" (y is max) devices in your account.</note>
+        <note annotates="source" from="developer">Example: You have "x of y" devices in your account, where y is the limit of allowed devices.</note>
       </trans-unit>
     </body>
   </file>
@@ -76,14 +86,11 @@
       <trans-unit id="vpn.servers.selectLocation">
         <source xml:space="preserve">Select location</source>
         <target xml:space="preserve">Seleziona posizione</target>
-        <context-group purpose="location"><context context-type="linenumber">15</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/views/ViewServers.qml</context><context context-type="linenumber">16</context></context-group>
         <note annotates="source" from="developer">Select the Location of the VPN server</note>
       </trans-unit>
       <trans-unit id="vpn.servers.currentLocation">
         <source xml:space="preserve">current location - %1</source>
         <target xml:space="preserve">posizione corrente: %1</target>
-        <context-group purpose="location"><context context-type="linenumber">18</context></context-group>
         <note annotates="source" from="developer">Accessibility description for current location of the VPN server</note>
       </trans-unit>
     </body>
@@ -93,70 +100,52 @@
       <trans-unit id="vpn.controller.deactivated">
         <source xml:space="preserve">VPN is off</source>
         <target xml:space="preserve">La VPN è disattivata</target>
-        <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">394</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.controller.activationSloagan">
         <source xml:space="preserve">Turn on to protect your privacy</source>
         <target xml:space="preserve">Attiva per proteggere la tua privacy</target>
-        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.controller.connecting">
         <source xml:space="preserve">Connecting</source>
         <target xml:space="preserve">Connessione</target>
-        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.controller.activating">
         <source xml:space="preserve">Masking connection and location</source>
         <target xml:space="preserve">Offuscamento connessione e posizione</target>
-        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.controller.activated">
         <source xml:space="preserve">VPN is on</source>
         <target xml:space="preserve">La VPN è attiva</target>
-        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.controller.active">
         <source xml:space="preserve">Secure and private</source>
         <target xml:space="preserve">Sicura e privata</target>
-        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
+        <note annotates="source" from="developer">Refers to the state of the users current internet connection</note>
       </trans-unit>
       <trans-unit id="vpn.controller.disconnecting">
         <source xml:space="preserve">Disconnecting…</source>
         <target xml:space="preserve">Disconnessione in corso…</target>
-        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.controller.deactivating">
         <source xml:space="preserve">Unmasking connection and location</source>
         <target xml:space="preserve">Disattivazione offuscamento connessione e posizione</target>
-        <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.controller.switching">
         <source xml:space="preserve">Switching…</source>
         <target xml:space="preserve">Passaggio in corso…</target>
-        <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.controller.switchingDetail">
         <source xml:space="preserve">From %1 to %2</source>
         <target xml:space="preserve">Da %1 a %2</target>
-        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
         <note annotates="source" from="developer">Switches from location 1 to location 2</note>
       </trans-unit>
       <trans-unit id="vpn.controller.info">
         <source xml:space="preserve">Connection Information</source>
         <target xml:space="preserve">Informazioni sulla connessione</target>
-        <context-group purpose="location"><context context-type="linenumber">506</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.main.settings">
         <source xml:space="preserve">Settings</source>
         <target xml:space="preserve">Impostazioni</target>
-        <context-group purpose="location"><context context-type="linenumber">536</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/settings/ViewSettingsMenu.qml</context><context context-type="linenumber">182</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -165,12 +154,10 @@
       <trans-unit id="vpn.devices.doDeviceRemoval">
         <source xml:space="preserve">Remove a device</source>
         <target xml:space="preserve">Rimuovi un dispositivo</target>
-        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.devices.maxDevicesReached">
         <source xml:space="preserve">You’ve reached your limit. To install the VPN on this device, you’ll need to remove one.</source>
         <target xml:space="preserve">È stato raggiunto il numero massimo di dispositivi. Per installare VPN su questo dispositivo, è necessario rimuoverne uno esistente.</target>
-        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -179,24 +166,6 @@
       <trans-unit id="vpn.main.getHelp">
         <source xml:space="preserve">Get Help</source>
         <target xml:space="preserve">Ottieni supporto</target>
-        <context-group purpose="location"><context context-type="linenumber">19</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/settings/ViewSettingsMenu.qml</context><context context-type="linenumber">56</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/views/ViewInitialize.qml</context><context context-type="linenumber">16</context></context-group>
-      </trans-unit>
-      <trans-unit id="vpn.help.contactUs">
-        <source xml:space="preserve">Contact us</source>
-        <target xml:space="preserve">Contattaci</target>
-        <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
-      </trans-unit>
-      <trans-unit id="vpn.help.helpAndSupport">
-        <source xml:space="preserve">Help &amp; Support</source>
-        <target xml:space="preserve">Guida e supporto</target>
-        <context-group purpose="location"><context context-type="linenumber">41</context></context-group>
-      </trans-unit>
-      <trans-unit id="vpn.help.viewLog">
-        <source xml:space="preserve">View log</source>
-        <target xml:space="preserve">Visualizza log</target>
-        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -205,19 +174,16 @@
       <trans-unit id="vpn.connectionInfo.kbps">
         <source xml:space="preserve">Kbps</source>
         <target xml:space="preserve">Kbps</target>
-        <context-group purpose="location"><context context-type="linenumber">19</context></context-group>
         <note annotates="source" from="developer">Kilobits per Secound</note>
       </trans-unit>
       <trans-unit id="vpn.connectioInfo.mbps">
         <source xml:space="preserve">Mbps</source>
         <target xml:space="preserve">Mbps</target>
-        <context-group purpose="location"><context context-type="linenumber">24</context></context-group>
         <note annotates="source" from="developer">Megabits per Second</note>
       </trans-unit>
       <trans-unit id="vpn.connectionInfo.gbps">
         <source xml:space="preserve">Gbps</source>
         <target xml:space="preserve">Gbps</target>
-        <context-group purpose="location"><context context-type="linenumber">28</context></context-group>
         <note annotates="source" from="developer">Gigabits per Second</note>
       </trans-unit>
     </body>
@@ -227,9 +193,25 @@
       <trans-unit id="vpn.main.back">
         <source xml:space="preserve">Back</source>
         <target xml:space="preserve">Indietro</target>
-        <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/settings/ViewSettingsMenu.qml</context><context context-type="linenumber">80</context></context-group>
         <note annotates="source" from="developer">Go back</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file datatype="plaintext" original="../src/ui/components/VPNRemoveDevicePopup.qml" source-language="en" target-language="it">
+    <body>
+      <trans-unit id="vpn.devices.removeDeviceQuestion">
+        <source xml:space="preserve">Remove device?</source>
+      </trans-unit>
+      <trans-unit id="vpn.devices.deviceRemovalConfirm">
+        <source xml:space="preserve">Please confirm you would like to remove\n%1.</source>
+        <note annotates="source" from="developer">%1 is the name of the device being removed. "\n" is used to display it on a new line, please keep it in the translation.</note>
+      </trans-unit>
+      <trans-unit id="vpn.devices.cancelDeviceRemoval">
+        <source xml:space="preserve">Cancel</source>
+      </trans-unit>
+      <trans-unit id="vpn.devices.removeDeviceButton">
+        <source xml:space="preserve">Remove</source>
+        <note annotates="source" from="developer">"This is the 'remove' device button.</note>
       </trans-unit>
     </body>
   </file>
@@ -237,8 +219,7 @@
     <body>
       <trans-unit id="cities">
         <source xml:space="preserve">Cities</source>
-        <target>Città</target>
-        <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
+        <target xml:space="preserve">Città</target>
         <note annotates="source" from="developer">The title of the cities list.</note>
       </trans-unit>
     </body>
@@ -248,7 +229,6 @@
       <trans-unit id="vpn.main.signOut">
         <source xml:space="preserve">Sign Out</source>
         <target xml:space="preserve">Disconnetti</target>
-        <context-group purpose="location"><context context-type="linenumber">10</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -257,13 +237,11 @@
       <trans-unit id="vpn.connectionStability.unstable">
         <source xml:space="preserve">Unstable</source>
         <target xml:space="preserve">Non stabile</target>
-        <context-group purpose="location"><context context-type="linenumber">15</context></context-group>
         <note annotates="source" from="developer">Unstable Connection</note>
       </trans-unit>
       <trans-unit id="vpn.connectionStability.noSignal">
         <source xml:space="preserve">No Signal</source>
         <target xml:space="preserve">Nessun segnale</target>
-        <context-group purpose="location"><context context-type="linenumber">17</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -272,40 +250,31 @@
       <trans-unit id="vpn.alert.authenticationError">
         <source xml:space="preserve">Authentication error</source>
         <target xml:space="preserve">Errore durante l’autenticazione</target>
-        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.alert.tryAgain">
         <source xml:space="preserve">Try again</source>
         <target xml:space="preserve">Riprova</target>
-        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.alert.unableToConnect">
         <source xml:space="preserve">Unable to connect</source>
         <target xml:space="preserve">Connessione non riuscita</target>
-        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.alert.noInternet">
         <source xml:space="preserve">No internet connection</source>
         <target xml:space="preserve">Nessuna connessione a Internet</target>
-        <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.alert.backgroundServiceError">
         <source xml:space="preserve">Background service error</source>
         <target xml:space="preserve">Errore del servizio in background</target>
-        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.alert.restore">
         <source xml:space="preserve">Restore</source>
         <target xml:space="preserve">Ripristina</target>
-        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
         <note annotates="source" from="developer">Restore a service in case of an Error</note>
       </trans-unit>
       <trans-unit id="vpn.alert.deviceRemovedAndLogout">
         <source xml:space="preserve">Signed out and device removed</source>
         <target xml:space="preserve">Disconnessione effettuata e dispositivo rimosso</target>
-        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -314,65 +283,18 @@
       <trans-unit id="vpn.toggle.on">
         <source xml:space="preserve">Turn VPN on</source>
         <target xml:space="preserve">Attiva VPN</target>
-        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.toggle.isOff">
         <source xml:space="preserve">VPN is off</source>
         <target xml:space="preserve">La VPN è disattivata</target>
-        <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.toggle.off">
         <source xml:space="preserve">Turn VPN off</source>
         <target xml:space="preserve">Disattiva VPN</target>
-        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.toggle.isOn">
         <source xml:space="preserve">VPN is on</source>
         <target xml:space="preserve">La VPN è attiva</target>
-        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
-      </trans-unit>
-    </body>
-  </file>
-  <file datatype="plaintext" original="../src/ui/main.qml" source-language="en" target-language="it">
-    <body>
-      <trans-unit id="vpn.main.productName">
-        <source xml:space="preserve">Mozilla VPN</source>
-        <target xml:space="preserve">Mozilla VPN</target>
-        <context-group purpose="location"><context context-type="linenumber">28</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/settings/ViewAboutUs.qml</context><context context-type="linenumber">56</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/views/ViewInitialize.qml</context><context context-type="linenumber">31</context></context-group>
-      </trans-unit>
-    </body>
-  </file>
-  <file datatype="plaintext" original="../src/ui/settings/ViewAboutUs.qml" source-language="en" target-language="it">
-    <body>
-      <trans-unit id="vpn.aboutUs.tos">
-        <source xml:space="preserve">Terms of Service</source>
-        <target xml:space="preserve">Condizioni di utilizzo del servizio</target>
-        <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
-      </trans-unit>
-      <trans-unit id="vpn.aboutUs.privacyPolicy">
-        <source xml:space="preserve">Privacy Policy</source>
-        <target xml:space="preserve">Informativa sulla privacy</target>
-        <context-group purpose="location"><context context-type="linenumber">26</context></context-group>
-      </trans-unit>
-      <trans-unit id="vpn.settings.aboutUs">
-        <source xml:space="preserve">About us</source>
-        <target xml:space="preserve">Informazioni</target>
-        <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/settings/ViewSettingsMenu.qml</context><context context-type="linenumber">49</context></context-group>
-      </trans-unit>
-      <trans-unit id="vpn.main.productDescription">
-        <source xml:space="preserve">A fast, secure and easy to use VPN. Built by the makers of Firefox.</source>
-        <target xml:space="preserve">Una VPN veloce, sicura e facile da utilizzare. Realizzata dagli autori di Firefox.</target>
-        <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/views/ViewInitialize.qml</context><context context-type="linenumber">33</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/main.cpp</context><context context-type="linenumber">60</context></context-group>
-      </trans-unit>
-      <trans-unit id="vpn.aboutUs.releaseVersion">
-        <source xml:space="preserve">Release Version</source>
-        <target xml:space="preserve">Versione</target>
-        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -381,25 +303,19 @@
       <trans-unit id="vpn.settings.language">
         <source xml:space="preserve">Language</source>
         <target xml:space="preserve">Lingua</target>
-        <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/settings/ViewSettingsMenu.qml</context><context context-type="linenumber">42</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.settings.system">
         <source xml:space="preserve">System</source>
         <target xml:space="preserve">Sistema</target>
-        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
         <note annotates="source" from="developer">The system language</note>
       </trans-unit>
       <trans-unit id="vpn.settings.languageAccessibleName">
         <source xml:space="preserve">%1 %2</source>
         <target xml:space="preserve">%1 %2</target>
-        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.settings.additional">
         <source xml:space="preserve">Additional</source>
         <target xml:space="preserve">Altre lingue</target>
-        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
         <note annotates="source" from="developer">List of the additional languages</note>
       </trans-unit>
     </body>
@@ -409,28 +325,22 @@
       <trans-unit id="vpn.settings.networking">
         <source xml:space="preserve">Network settings</source>
         <target xml:space="preserve">Impostazioni di rete</target>
-        <context-group purpose="location"><context context-type="linenumber">18</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/settings/ViewSettingsMenu.qml</context><context context-type="linenumber">35</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.settings.ipv6">
         <source xml:space="preserve">IPv6</source>
         <target xml:space="preserve">IPv6</target>
-        <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.settings.ipv6.description">
         <source xml:space="preserve">Push the internet forward with the latest version of the Internet Protocol</source>
         <target xml:space="preserve">Contribuisci al progresso di internet utilizzando la versione più recente del protocollo internet.</target>
-        <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.settings.lanAccess">
         <source xml:space="preserve">Local network access</source>
         <target xml:space="preserve">Accesso alla rete locale</target>
-        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.settings.lanAccess.description">
         <source xml:space="preserve">Access printers, streaming sticks and all other devices on your local network</source>
         <target xml:space="preserve">Accedi a stampanti, chiavette per lo streaming e tutti gli altri dispositivi sulla tua rete locale</target>
-        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -439,18 +349,14 @@
       <trans-unit id="vpn.settings.notifications">
         <source xml:space="preserve">Notifications</source>
         <target xml:space="preserve">Notifiche</target>
-        <context-group purpose="location"><context context-type="linenumber">16</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/settings/ViewSettingsMenu.qml</context><context context-type="linenumber">28</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.settings.guestWifiAlert">
         <source xml:space="preserve">Guest Wi-Fi portal alert</source>
         <target xml:space="preserve">Avviso portale Wi-Fi per ospiti</target>
-        <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.settings.guestWifiAlert.description">
         <source xml:space="preserve">Get notified if a guest Wi-Fi portal is blocked due to VPN connection</source>
         <target xml:space="preserve">Ricevi una notifica se un portale Wi-Fi è bloccato dalla connessione VPN</target>
-        <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -459,24 +365,19 @@
       <trans-unit id="vpn.settings.giveFeedback">
         <source xml:space="preserve">Give feedback</source>
         <target xml:space="preserve">Invia feedback</target>
-        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.settings.user">
         <source xml:space="preserve">VPN User</source>
         <target xml:space="preserve">Utente VPN</target>
-        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.main.manageAccount">
         <source xml:space="preserve">Manage account</source>
         <target xml:space="preserve">Gestisci account</target>
-        <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/views/ViewUpdate.qml</context><context context-type="linenumber">209</context></context-group>
         <note annotates="source" from="developer">"Manage account"</note>
       </trans-unit>
       <trans-unit id="vpn.settings.runOnBoot">
         <source xml:space="preserve">Launch VPN app on Startup</source>
         <target xml:space="preserve">Avvia l’app VPN all'avvio</target>
-        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
         <note annotates="source" from="developer">The back of the object, not the front</note>
       </trans-unit>
     </body>
@@ -486,12 +387,10 @@
       <trans-unit id="vpn.authenticating.waitForSignIn">
         <source xml:space="preserve">Waiting for sign in and subscription confirmation…</source>
         <target xml:space="preserve">In attesa dell’accesso e della conferma dell’abbonamento…</target>
-        <context-group purpose="location"><context context-type="linenumber">16</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.authenticating.cancelAndRetry">
         <source xml:space="preserve">Cancel and try again</source>
         <target xml:space="preserve">Annulla e riprova</target>
-        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -500,36 +399,18 @@
       <trans-unit id="vpn.postAuthentication..quickAccess">
         <source xml:space="preserve">Quick access</source>
         <target xml:space="preserve">Accesso rapido</target>
-        <context-group purpose="location"><context context-type="linenumber">19</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.postAuthentication.statusBarIntro">
         <source xml:space="preserve">You can quickly access Mozilla VPN from your status bar.</source>
         <target xml:space="preserve">È possibile accedere rapidamente a Mozilla VPN dalla barra di stato.</target>
-        <context-group purpose="location"><context context-type="linenumber">28</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.postAuthentication.wip">
         <source xml:space="preserve">WIP</source>
         <target xml:space="preserve">WIP</target>
-        <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.postAuthentication.continue">
         <source xml:space="preserve">Continue</source>
         <target xml:space="preserve">Continua</target>
-        <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
-      </trans-unit>
-    </body>
-  </file>
-  <file datatype="plaintext" original="../src/ui/states/StateSubscriptionNeeded.qml" source-language="en" target-language="it">
-    <body>
-      <trans-unit id="vpn.iap.subscriptionNeeded">
-        <source xml:space="preserve">Subscription needed</source>
-        <target xml:space="preserve">È necessario un abbonamento</target>
-        <context-group purpose="location"><context context-type="linenumber">19</context></context-group>
-      </trans-unit>
-      <trans-unit id="vpn.iap.subscribeNow">
-        <source xml:space="preserve">Subscribe now</source>
-        <target xml:space="preserve">Abbonati adesso</target>
-        <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -538,54 +419,28 @@
       <trans-unit id="vpn.devices.deviceAccessibleName">
         <source xml:space="preserve">%1 %2</source>
         <target xml:space="preserve">%1 %2</target>
-        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+        <note annotates="source" from="developer">Example: "deviceName deviceDescription"</note>
       </trans-unit>
       <trans-unit id="vpn.devices.currentDevice">
         <source xml:space="preserve">Current Device</source>
         <target xml:space="preserve">Dispositivo corrente</target>
-        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.devices.addedltHour">
         <source xml:space="preserve">Added less than an hour ago</source>
         <target xml:space="preserve">Aggiunto meno di un’ora fa</target>
-        <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.devices.addedXhoursAgo">
         <source xml:space="preserve">Added a few hours ago (%1)</source>
         <target xml:space="preserve">Aggiunto alcune ore fa (%1)</target>
-        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.devices.addedXdaysAgo">
         <source xml:space="preserve">Added %1 days ago</source>
         <target xml:space="preserve">Aggiunto %1 giorni fa</target>
-        <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.devices.removeA11Y">
         <source xml:space="preserve">Remove %1</source>
         <target xml:space="preserve">Rimuovi %1</target>
-        <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
-        <note annotates="source" from="developer">"This is a label to make the icon button accessible</note>
-      </trans-unit>
-      <trans-unit id="vpn.devices.removeDeviceQuestion">
-        <source xml:space="preserve">Remove device?</source>
-        <target xml:space="preserve">Rimuovere il dispositivo?</target>
-        <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
-      </trans-unit>
-      <trans-unit id="vpn.devices.deviceRemovalConfirm">
-        <source xml:space="preserve">Please confirm you would like to remove\n%1.</source>
-        <target xml:space="preserve">Confermare la rimozione del dispositivo\n %1.</target>
-        <context-group purpose="location"><context context-type="linenumber">398</context></context-group>
-      </trans-unit>
-      <trans-unit id="vpn.devices.cancelDeviceRemoval">
-        <source xml:space="preserve">Cancel</source>
-        <target xml:space="preserve">Annulla</target>
-        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
-      </trans-unit>
-      <trans-unit id="vpn.devices.removeDeviceButton">
-        <source xml:space="preserve">Remove</source>
-        <target xml:space="preserve">Rimuovi</target>
-        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
-        <note annotates="source" from="developer">"This is the 'remove' device button.</note>
+        <note annotates="source" from="developer">Label used for accessibility on the button to remove a device</note>
       </trans-unit>
     </body>
   </file>
@@ -594,13 +449,17 @@
       <trans-unit id="vpn.main.getStarted">
         <source xml:space="preserve">Get started</source>
         <target xml:space="preserve">Per iniziare</target>
-        <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/views/ViewOnboarding.qml</context><context context-type="linenumber">57</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.main.learnMore">
         <source xml:space="preserve">Learn more</source>
         <target xml:space="preserve">Ulteriori informazioni</target>
-        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
+      </trans-unit>
+    </body>
+  </file>
+  <file datatype="plaintext" original="../src/ui/views/ViewLogs.qml" source-language="en" target-language="it">
+    <body>
+      <trans-unit id="vpn.viewlogs.title">
+        <source xml:space="preserve">View Logs</source>
       </trans-unit>
     </body>
   </file>
@@ -608,19 +467,15 @@
     <body>
       <trans-unit id="MozillaVPN">
         <source xml:space="preserve">Mozilla VPN</source>
-        <target>Mozilla VPN</target>
-        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
+        <target xml:space="preserve">Mozilla VPN</target>
       </trans-unit>
       <trans-unit id="vpn.updates.newVersionAvailable">
         <source xml:space="preserve">New version is available.</source>
         <target xml:space="preserve">È disponibile una nuova versione.</target>
-        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.updates.updateNow">
         <source xml:space="preserve">Update now</source>
         <target xml:space="preserve">Aggiorna adesso</target>
-        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../src/ui/views/ViewUpdate.qml</context><context context-type="linenumber">194</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -629,12 +484,50 @@
       <trans-unit id="vpn.onboarding.skip">
         <source xml:space="preserve">Skip</source>
         <target xml:space="preserve">Ignora</target>
-        <context-group purpose="location"><context context-type="linenumber">26</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.onboarding.next">
         <source xml:space="preserve">Next</source>
         <target xml:space="preserve">Successivo</target>
-        <context-group purpose="location"><context context-type="linenumber">54</context></context-group>
+      </trans-unit>
+    </body>
+  </file>
+  <file datatype="plaintext" original="../src/ui/views/ViewSubscriptionNeeded.qml" source-language="en" target-language="it">
+    <body>
+      <trans-unit id="vpn.subscription.title">
+        <source xml:space="preserve">Subscribe for %1/mo</source>
+      </trans-unit>
+      <trans-unit id="vpn.subscription.moneyBackGuarantee">
+        <source xml:space="preserve">30-day money-back guarantee</source>
+      </trans-unit>
+      <trans-unit id="vpn.subscription.featureTitle1">
+        <source xml:space="preserve">No activity logs</source>
+      </trans-unit>
+      <trans-unit id="vpn.subscription.featureSubtitle1">
+        <source xml:space="preserve">We're Mozilla. We're on your side.</source>
+      </trans-unit>
+      <trans-unit id="vpn.subscription.featureTitle2">
+        <source xml:space="preserve">No one can track you</source>
+      </trans-unit>
+      <trans-unit id="vpn.subscription.featureSubtitle2">
+        <source xml:space="preserve">We encrypt your entire device.</source>
+      </trans-unit>
+      <trans-unit id="vpn.subscription.featureTitle3">
+        <source xml:space="preserve">%1+ servers in %2+ countries</source>
+      </trans-unit>
+      <trans-unit id="vpn.subscription.featureSubtitle3">
+        <source xml:space="preserve">Protect your access to the web.</source>
+      </trans-unit>
+      <trans-unit id="vpn.subscription.featureTitle4">
+        <source xml:space="preserve">Connect up to %1 devices</source>
+      </trans-unit>
+      <trans-unit id="vpn.subscription.featureSubtitle4">
+        <source xml:space="preserve">We won't restrict your bandwidth.</source>
+      </trans-unit>
+      <trans-unit id="vpn.updates.subscribeNow">
+        <source xml:space="preserve">Subscribe now</source>
+      </trans-unit>
+      <trans-unit id="vpn.main.restorePurchases">
+        <source xml:space="preserve">Restore purchases</source>
       </trans-unit>
     </body>
   </file>
@@ -643,32 +536,23 @@
       <trans-unit id="vpn.updates.updateRecomended">
         <source xml:space="preserve">Update recommended</source>
         <target xml:space="preserve">Aggiornamento consigliato</target>
-        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.updates.updateRecomended.description">
-        <source xml:space="preserve">Please update the app before you\ncontinue to use the VPN</source>
-        <target xml:space="preserve">Aggiornare l’app prima di\ncontinuare a utilizzare la VPN</target>
-        <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
+        <source xml:space="preserve">Please update the app before you continue to use the VPN</source>
       </trans-unit>
       <trans-unit id="vpn.updates.updateRequired">
-        <source xml:space="preserve">Update Required</source>
-        <target xml:space="preserve">Aggiornamento richiesto</target>
-        <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
+        <source xml:space="preserve">Update required</source>
       </trans-unit>
       <trans-unit id="vpn.updates.updateRequire.reason">
-        <source xml:space="preserve">We detected and fixed a serious bug.\nYou must update your app.</source>
-        <target xml:space="preserve">Abbiamo identificato e risolto un problema grave.\nÈ necessario aggiornare l’app.</target>
-        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
+        <source xml:space="preserve">We detected and fixed a serious bug. You must update your app.</source>
       </trans-unit>
       <trans-unit id="vpn.updates.updateConnectionInsecureWarning">
         <source xml:space="preserve">Your connection will not be secure while you update.</source>
         <target xml:space="preserve">La connessione non sarà sicura durante l'aggiornamento.</target>
-        <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.updates.notNow">
         <source xml:space="preserve">Not now</source>
         <target xml:space="preserve">Non adesso</target>
-        <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
       </trans-unit>
     </body>
   </file>
@@ -677,8 +561,7 @@
       <trans-unit id="vpn.connectionInfo.unknown">
         <source xml:space="preserve">Unknown</source>
         <target xml:space="preserve">sconosciuto</target>
-        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
-        <note annotates="source" from="developer">Context - "The current ip-address is: unknown"</note>
+        <note annotates="source" from="developer">This refers to the current IP address, i.e. "IP: Unknown".</note>
       </trans-unit>
     </body>
   </file>
@@ -687,101 +570,107 @@
       <trans-unit id="vpn.main.startMinimized">
         <source xml:space="preserve">Start minimized</source>
         <target xml:space="preserve">Avvia ridotto a icona</target>
-        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.main.startOnBoot">
         <source xml:space="preserve">Start at boot (if configured)</source>
         <target xml:space="preserve">Esegui all’avvio (se configurato)</target>
-        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
+      </trans-unit>
+    </body>
+  </file>
+  <file datatype="cpp" original="../src/models/helpmodel.cpp" source-language="en" target-language="it">
+    <body>
+      <trans-unit id="help.viewLog">
+        <source xml:space="preserve">View log</source>
+      </trans-unit>
+      <trans-unit id="help.supportWebsite">
+        <source xml:space="preserve">Support Website</source>
+      </trans-unit>
+      <trans-unit id="help.contactUs">
+        <source xml:space="preserve">Contact us</source>
+      </trans-unit>
+    </body>
+  </file>
+  <file datatype="cpp" original="../src/platforms/macos/macosmenubar.cpp" source-language="en" target-language="it">
+    <body>
+      <trans-unit id="menubar.file.title">
+        <source xml:space="preserve">File</source>
+      </trans-unit>
+      <trans-unit id="menubar.file.close">
+        <source xml:space="preserve">Close</source>
+      </trans-unit>
+      <trans-unit id="menubar.help.title">
+        <source xml:space="preserve">Help</source>
       </trans-unit>
     </body>
   </file>
   <file datatype="cpp" original="../src/systemtrayhandler.cpp" source-language="en" target-language="it">
     <body>
+      <trans-unit id="systray.disconnect">
+        <source xml:space="preserve">Disconnect</source>
+      </trans-unit>
+      <trans-unit id="systray.show">
+        <source xml:space="preserve">Show Mozilla VPN</source>
+      </trans-unit>
+      <trans-unit id="systray.help">
+        <source xml:space="preserve">Help</source>
+      </trans-unit>
+      <trans-unit id="systray.preferences">
+        <source xml:space="preserve">Preferences…</source>
+      </trans-unit>
       <trans-unit id="systray.quit">
-        <source xml:space="preserve">Quit</source>
-        <target xml:space="preserve">Esci</target>
-        <context-group purpose="location"><context context-type="linenumber">18</context></context-group>
+        <source xml:space="preserve">Quit Mozilla VPN</source>
       </trans-unit>
-      <trans-unit id="vpn.systray.statusConnected">
-        <source xml:space="preserve">Mozilla VPN connected</source>
-        <target xml:space="preserve">Mozilla VPN connessa</target>
-        <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
+      <trans-unit id="vpn.systray.status.connectedTo">
+        <source xml:space="preserve">Connected to:</source>
       </trans-unit>
-      <trans-unit id="TODO">
-        <source xml:space="preserve"/>
-        <target xml:space="preserve">.</target>
-        <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
+      <trans-unit id="vpn.systray.status.connectTo">
+        <source xml:space="preserve">Connect to the last location:</source>
       </trans-unit>
-      <trans-unit id="vpn.systray.statusDisconnected">
-        <source xml:space="preserve">Mozilla VPN disconnected</source>
-        <target xml:space="preserve">Mozilla VPN disconnessa</target>
-        <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
+      <trans-unit id="vpn.systray.status.connectingTo">
+        <source xml:space="preserve">Connecting to:</source>
       </trans-unit>
-      <trans-unit id="vpn.systray.statusSwitch">
-        <source xml:space="preserve">Mozilla VPN switching</source>
-        <target xml:space="preserve">Mozilla VPN passaggio in corso</target>
-        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
-        <note annotates="source" from="developer">This message is shown when the VPN is switching to a different server in a different location.</note>
+      <trans-unit id="vpn.systray.status.disconnectingFrom">
+        <source xml:space="preserve">Disconnecting from:</source>
+      </trans-unit>
+      <trans-unit id="vpn.systray.location">
+        <source xml:space="preserve">%1, %2</source>
+        <note annotates="source" from="developer">Location in the systray. %1 is the country, %2 is the city.</note>
       </trans-unit>
       <trans-unit id="vpn.systray.statusConnected.title">
         <source xml:space="preserve">VPN Connected</source>
-        <target>VPN connessa</target>
-        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+        <target xml:space="preserve">VPN connessa</target>
       </trans-unit>
       <trans-unit id="vpn.systray.statusConnected.message">
         <source xml:space="preserve">Connected to %1, %2</source>
-        <target>Connessa con %1 (%2)</target>
-        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
+        <target xml:space="preserve">Connessa con %1 (%2)</target>
         <note annotates="source" from="developer">Shown as message body in a notification. %1 is the country, %2 is the city.</note>
-      </trans-unit>
-      <trans-unit id="vpn.systray.captivePortalAlert">
-        <source xml:space="preserve">Captive portal detected</source>
-        <target xml:space="preserve">Rilevato captive portal</target>
-        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
       </trans-unit>
       <trans-unit id="vpn.systray.statusDisconnected.title">
         <source xml:space="preserve">VPN Disconnected</source>
-        <target>VPN disconnessa</target>
-        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
+        <target xml:space="preserve">VPN disconnessa</target>
       </trans-unit>
       <trans-unit id="vpn.systray.statusDisconnected.message">
         <source xml:space="preserve">Disconnected from to %1, %2</source>
-        <target>Disconnessa da %1 (%2)</target>
-        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
+        <target xml:space="preserve">Disconnessa da %1 (%2)</target>
         <note annotates="source" from="developer">Shown as message body in a notification. %1 is the country, %2 is the city.</note>
       </trans-unit>
       <trans-unit id="vpn.systray.statusSwitch.title">
         <source xml:space="preserve">VPN Switched Servers</source>
-        <target>La VPN è passata a un altro server</target>
-        <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
+        <target xml:space="preserve">La VPN è passata a un altro server</target>
       </trans-unit>
       <trans-unit id="vpn.systray.statusSwtich.message">
         <source xml:space="preserve">Switched from %1, %2 to %3, %4</source>
-        <target>Passaggio da %1 (%2) a %3 (%4)</target>
-        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+        <target xml:space="preserve">Passaggio da %1 (%2) a %3 (%4)</target>
         <note annotates="source" from="developer">Shown as message body in a notification. %1 and %3 are countries, %2 and %4 are cities.</note>
       </trans-unit>
       <trans-unit id="vpn.systray.captivePortalAlert.title">
         <source xml:space="preserve">Captive portal detected</source>
-        <target>Rilevato captive portal</target>
-        <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
+        <target xml:space="preserve">Rilevato captive portal</target>
       </trans-unit>
       <trans-unit id="vpn.systray.captivePortalAlert.message">
-        <source xml:space="preserve">VPN will automatically reconnect when ready
-</source>
-        <target>La VPN si riconnetterà automaticamente non appena possibile</target>
-        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
+        <source xml:space="preserve">VPN will automatically reconnect when ready</source>
       </trans-unit>
-      <group resname="SystemTrayHandler" restype="x-trolltech-linguist-context">
-        <trans-unit id="_msg1">
-        <source xml:space="preserve">TODO</source>
-        <target xml:space="preserve">TODO</target>
-        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
-      </trans-unit>
-      </group>
     </body>
   </file>
 </xliff>
+


### PR DESCRIPTION
CC @mathjazz 

@strseb 
Adding only strings to English doesn't seem to work. The new strings show up in Pontoon as missing, but they are not committed to the repository.

I think that's a bug that needs to be fixed in Pontoon, in the meantime I'm using a local script to add missing strings to other locales. Hopefully we won't need to use it in automation.