### PR TITLE
Remove token to clone VPN repo

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -22,7 +22,6 @@ jobs:
         with:
           repository: "mozilla-mobile/mozilla-vpn-client"
           path: "vpn"
-          token: ${{ secrets.ACCESSCODE }}
       - name: Set up Python 3
         uses: actions/setup-python@v2
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mozilla VPN localization
 
-Localization for the Mozilla VPN project.
+Localization for the [Mozilla VPN Client](https://github.com/mozilla-mobile/mozilla-vpn-client).
 
 ## License
 


### PR DESCRIPTION
cc @strseb and @bakulf 

I don't think we need the token anymore, since the repository is public. I'll remove it from the repository's setting once I verified that everything still works.