### PR TITLE
Clean up xml:space attributes in source file

### DIFF
--- a/.github/extract_source_strings.py
+++ b/.github/extract_source_strings.py
@@ -9,14 +9,14 @@ from lxml import etree, objectify
 from translate.misc.xml_helpers import reindent
 import os
 
-VPN_PROJECT_DIR = "vpn"
-OUT_PROJECT_DIR = "translationFiles"
+vpn_project_folder = "vpn"
+output_folder = "translationFiles"
 
-srcFile = os.path.join(VPN_PROJECT_DIR, "src", "src.pro")
+srcFile = os.path.join(vpn_project_folder, "src", "src.pro")
 os.system(f"lupdate {srcFile} -ts")
 
-filePath = os.path.join(VPN_PROJECT_DIR, "translations", "mozillavpn_en.ts")
-outFile = os.path.join(OUT_PROJECT_DIR, "en", "mozillavpn.xliff")
+filePath = os.path.join(vpn_project_folder, "translations", "mozillavpn_en.ts")
+outFile = os.path.join(output_folder, "en", "mozillavpn.xliff")
 
 # Update English XLIFF file
 print(f"Updating {outFile}")
@@ -28,10 +28,17 @@ tree = etree.parse(outFile)
 root = tree.getroot()
 objectify.deannotate(root, cleanup_namespaces=True)
 
-# Remove empty targets
+# Remove targets (i.e. translations) if present, since this is the reference
+# locale
 for target in root.xpath("//x:target", namespaces=NS):
     if target is not None:
         target.getparent().remove(target)
+
+# Remove the xml:space attribute in the <source>, since it's not used when
+# exporting back to .ts
+for source in root.xpath("//x:source", namespaces=NS):
+    attrib_name = "{http://www.w3.org/XML/1998/namespace}space"
+    source.attrib.pop(attrib_name)
 
 # Change QT <extracomment> elements into <notes>
 for extracomment in root.xpath("//x:extracomment", namespaces=NS):

--- a/.github/update_other_locales.py
+++ b/.github/update_other_locales.py
@@ -157,16 +157,6 @@ def main():
                 # Create a target node and insert it after source.
                 child = etree.Element("target")
                 child.text = translations[string_id]
-
-                # If the source target has a preserve attribute, add it to the
-                # target as well.
-                attrib_name = "{http://www.w3.org/XML/1998/namespace}space"
-                xml_space = trans_node.xpath("./x:source", namespaces=NS)[0].get(
-                    attrib_name
-                )
-                if xml_space is not None:
-                    child.set(attrib_name, xml_space)
-
                 trans_node.insert(1, child)
 
         # Update target-language where defined

--- a/it/mozillavpn.xliff
+++ b/it/mozillavpn.xliff
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="vpn.main.back">
         <source xml:space="preserve">Back</source>
-        <target xml:space="preserve">Indietro</target>
+        <target>Indietro</target>
         <note annotates="source" from="developer">Go back</note>
       </trans-unit>
       <trans-unit id="vpn.android.authentication">
         <source xml:space="preserve">Authentication</source>
-        <target xml:space="preserve">Autenticazione</target>
+        <target>Autenticazione</target>
       </trans-unit>
     </body>
   </file>
@@ -17,27 +17,27 @@
     <body>
       <trans-unit id="vpn.aboutUs.tos">
         <source xml:space="preserve">Terms of Service</source>
-        <target xml:space="preserve">Condizioni di utilizzo del servizio</target>
+        <target>Condizioni di utilizzo del servizio</target>
       </trans-unit>
       <trans-unit id="vpn.aboutUs.privacyPolicy">
         <source xml:space="preserve">Privacy Policy</source>
-        <target xml:space="preserve">Informativa sulla privacy</target>
+        <target>Informativa sulla privacy</target>
       </trans-unit>
       <trans-unit id="vpn.settings.aboutUs">
         <source xml:space="preserve">About us</source>
-        <target xml:space="preserve">Informazioni</target>
+        <target>Informazioni</target>
       </trans-unit>
       <trans-unit id="vpn.main.productName">
         <source xml:space="preserve">Mozilla VPN</source>
-        <target xml:space="preserve">Mozilla VPN</target>
+        <target>Mozilla VPN</target>
       </trans-unit>
       <trans-unit id="vpn.main.productDescription">
         <source xml:space="preserve">A fast, secure and easy to use VPN. Built by the makers of Firefox.</source>
-        <target xml:space="preserve">Una VPN veloce, sicura e facile da utilizzare. Realizzata dagli autori di Firefox.</target>
+        <target>Una VPN veloce, sicura e facile da utilizzare. Realizzata dagli autori di Firefox.</target>
       </trans-unit>
       <trans-unit id="vpn.aboutUs.releaseVersion">
         <source xml:space="preserve">Release Version</source>
-        <target xml:space="preserve">Versione</target>
+        <target>Versione</target>
         <note annotates="source" from="developer">Refers to the installed version. For example: "Release Version: 1.23"</note>
       </trans-unit>
     </body>
@@ -46,12 +46,12 @@
     <body>
       <trans-unit id="vpn.turnOffAlert.enabling">
         <source xml:space="preserve">VPN must be off before enabling</source>
-        <target xml:space="preserve">La VPN deve essere disattivata per attivare questa impostazione</target>
+        <target>La VPN deve essere disattivata per attivare questa impostazione</target>
         <note annotates="source" from="developer">Associated to a setting that requires the VPN to be disconnected to change state</note>
       </trans-unit>
       <trans-unit id="vpn.turnOffAlert.disabling">
         <source xml:space="preserve">VPN must be off before disabling</source>
-        <target xml:space="preserve">La VPN deve essere disattivata per disattivare questa impostazione</target>
+        <target>La VPN deve essere disattivata per disattivare questa impostazione</target>
         <note annotates="source" from="developer">Associated to a setting that requires the VPN to be disconnected to change state</note>
       </trans-unit>
     </body>
@@ -60,22 +60,22 @@
     <body>
       <trans-unit id="vpn.connectionInfo.ip">
         <source xml:space="preserve">IP: %1</source>
-        <target xml:space="preserve">IP: %1</target>
+        <target>IP: %1</target>
         <note annotates="source" from="developer">The current IP address</note>
       </trans-unit>
       <trans-unit id="vpn.connectionInfo.download">
         <source xml:space="preserve">Download</source>
-        <target xml:space="preserve">Download</target>
+        <target>Download</target>
         <note annotates="source" from="developer">The current download speed. The speed is shown on the next line.</note>
       </trans-unit>
       <trans-unit id="vpn.connectionInfo.upload">
         <source xml:space="preserve">Upload</source>
-        <target xml:space="preserve">Upload</target>
+        <target>Upload</target>
         <note annotates="source" from="developer">The current upload speed. The speed is shown on the next line.</note>
       </trans-unit>
       <trans-unit id="vpn.connectionInfo.close">
         <source xml:space="preserve">Close</source>
-        <target xml:space="preserve">Chiudi</target>
+        <target>Chiudi</target>
       </trans-unit>
     </body>
   </file>
@@ -83,7 +83,7 @@
     <body>
       <trans-unit id="vpn.connectionStability.checkConnection">
         <source xml:space="preserve">Check Connection</source>
-        <target xml:space="preserve">Verifica connessione</target>
+        <target>Verifica connessione</target>
       </trans-unit>
     </body>
   </file>
@@ -91,11 +91,11 @@
     <body>
       <trans-unit id="vpn.devices.myDevices">
         <source xml:space="preserve">My devices</source>
-        <target xml:space="preserve">I miei dispositivi</target>
+        <target>I miei dispositivi</target>
       </trans-unit>
       <trans-unit id="vpn.devices.activeVsMaxDeviceCount">
         <source xml:space="preserve">%1 of %2</source>
-        <target xml:space="preserve">%1 di %2</target>
+        <target>%1 di %2</target>
         <note annotates="source" from="developer">Example: You have "x of y" devices in your account, where y is the limit of allowed devices.</note>
       </trans-unit>
     </body>
@@ -104,12 +104,12 @@
     <body>
       <trans-unit id="vpn.servers.selectLocation">
         <source xml:space="preserve">Select location</source>
-        <target xml:space="preserve">Seleziona posizione</target>
+        <target>Seleziona posizione</target>
         <note annotates="source" from="developer">Select the Location of the VPN server</note>
       </trans-unit>
       <trans-unit id="vpn.servers.currentLocation">
         <source xml:space="preserve">current location - %1</source>
-        <target xml:space="preserve">posizione corrente: %1</target>
+        <target>posizione corrente: %1</target>
         <note annotates="source" from="developer">Accessibility description for current location of the VPN server</note>
       </trans-unit>
     </body>
@@ -118,53 +118,53 @@
     <body>
       <trans-unit id="vpn.controller.deactivated">
         <source xml:space="preserve">VPN is off</source>
-        <target xml:space="preserve">La VPN è disattivata</target>
+        <target>La VPN è disattivata</target>
       </trans-unit>
       <trans-unit id="vpn.controller.activationSloagan">
         <source xml:space="preserve">Turn on to protect your privacy</source>
-        <target xml:space="preserve">Attiva per proteggere la tua privacy</target>
+        <target>Attiva per proteggere la tua privacy</target>
       </trans-unit>
       <trans-unit id="vpn.controller.connecting">
         <source xml:space="preserve">Connecting</source>
-        <target xml:space="preserve">Connessione</target>
+        <target>Connessione</target>
       </trans-unit>
       <trans-unit id="vpn.controller.activating">
         <source xml:space="preserve">Masking connection and location</source>
-        <target xml:space="preserve">Offuscamento connessione e posizione</target>
+        <target>Offuscamento connessione e posizione</target>
       </trans-unit>
       <trans-unit id="vpn.controller.activated">
         <source xml:space="preserve">VPN is on</source>
-        <target xml:space="preserve">La VPN è attiva</target>
+        <target>La VPN è attiva</target>
       </trans-unit>
       <trans-unit id="vpn.controller.active">
         <source xml:space="preserve">Secure and private</source>
-        <target xml:space="preserve">Sicura e privata</target>
+        <target>Sicura e privata</target>
         <note annotates="source" from="developer">This refers to the user’s internet connection.</note>
       </trans-unit>
       <trans-unit id="vpn.controller.disconnecting">
         <source xml:space="preserve">Disconnecting…</source>
-        <target xml:space="preserve">Disconnessione in corso…</target>
+        <target>Disconnessione in corso…</target>
       </trans-unit>
       <trans-unit id="vpn.controller.deactivating">
         <source xml:space="preserve">Unmasking connection and location</source>
-        <target xml:space="preserve">Disattivazione offuscamento connessione e posizione</target>
+        <target>Disattivazione offuscamento connessione e posizione</target>
       </trans-unit>
       <trans-unit id="vpn.controller.switching">
         <source xml:space="preserve">Switching…</source>
-        <target xml:space="preserve">Passaggio in corso…</target>
+        <target>Passaggio in corso…</target>
       </trans-unit>
       <trans-unit id="vpn.controller.switchingDetail">
         <source xml:space="preserve">From %1 to %2</source>
-        <target xml:space="preserve">Da %1 a %2</target>
+        <target>Da %1 a %2</target>
         <note annotates="source" from="developer">Switches from location 1 to location 2</note>
       </trans-unit>
       <trans-unit id="vpn.controller.info">
         <source xml:space="preserve">Connection Information</source>
-        <target xml:space="preserve">Informazioni sulla connessione</target>
+        <target>Informazioni sulla connessione</target>
       </trans-unit>
       <trans-unit id="vpn.main.settings">
         <source xml:space="preserve">Settings</source>
-        <target xml:space="preserve">Impostazioni</target>
+        <target>Impostazioni</target>
       </trans-unit>
     </body>
   </file>
@@ -172,11 +172,11 @@
     <body>
       <trans-unit id="vpn.devices.doDeviceRemoval">
         <source xml:space="preserve">Remove a device</source>
-        <target xml:space="preserve">Rimuovi un dispositivo</target>
+        <target>Rimuovi un dispositivo</target>
       </trans-unit>
       <trans-unit id="vpn.devices.maxDevicesReached">
         <source xml:space="preserve">You’ve reached your limit. To install the VPN on this device, you’ll need to remove one.</source>
-        <target xml:space="preserve">È stato raggiunto il numero massimo di dispositivi. Per installare VPN su questo dispositivo, è necessario rimuoverne uno esistente.</target>
+        <target>È stato raggiunto il numero massimo di dispositivi. Per installare VPN su questo dispositivo, è necessario rimuoverne uno esistente.</target>
       </trans-unit>
     </body>
   </file>
@@ -184,7 +184,7 @@
     <body>
       <trans-unit id="vpn.main.getHelp">
         <source xml:space="preserve">Get Help</source>
-        <target xml:space="preserve">Ottieni supporto</target>
+        <target>Ottieni supporto</target>
       </trans-unit>
     </body>
   </file>
@@ -192,22 +192,22 @@
     <body>
       <trans-unit id="vpn.connectionInfo.kbps">
         <source xml:space="preserve">Kbps</source>
-        <target xml:space="preserve">Kbps</target>
+        <target>Kbps</target>
         <note annotates="source" from="developer">Kilobits per Secound</note>
       </trans-unit>
       <trans-unit id="vpn.connectioInfo.mbps">
         <source xml:space="preserve">Mbps</source>
-        <target xml:space="preserve">Mbps</target>
+        <target>Mbps</target>
         <note annotates="source" from="developer">Megabits per Second</note>
       </trans-unit>
       <trans-unit id="vpn.connectionInfo.gbps">
         <source xml:space="preserve">Gbps</source>
-        <target xml:space="preserve">Gbps</target>
+        <target>Gbps</target>
         <note annotates="source" from="developer">Gigabits per Second</note>
       </trans-unit>
       <trans-unit id="vpn.connectionInfo.accessibleName">
         <source xml:space="preserve">%1: %2 %3</source>
-        <target xml:space="preserve">%1: %2 %3</target>
+        <target>%1: %2 %3</target>
         <note annotates="source" from="developer">Used as accessibility description for the connection info: %1 is the localized label for “Upload” or “Download”, %2 is the speed value, %3 is the localized unit. Example: “Upload: 10 Mbps”.</note>
       </trans-unit>
     </body>
@@ -216,7 +216,7 @@
     <body>
       <trans-unit id="vpn.authenticating.cancelAndRetry">
         <source xml:space="preserve">Cancel and try again</source>
-        <target xml:space="preserve">Annulla e riprova</target>
+        <target>Annulla e riprova</target>
       </trans-unit>
     </body>
   </file>
@@ -224,21 +224,21 @@
     <body>
       <trans-unit id="vpn.devices.removeDeviceQuestion">
         <source xml:space="preserve">Remove device?</source>
-        <target xml:space="preserve">Rimuovere il dispositivo?</target>
+        <target>Rimuovere il dispositivo?</target>
       </trans-unit>
       <trans-unit id="vpn.devices.deviceRemovalConfirm">
         <source xml:space="preserve">Please confirm you would like to remove
 %1.</source>
-        <target xml:space="preserve">Confermare la rimozione del dispositivo %1.</target>
+        <target>Confermare la rimozione del dispositivo %1.</target>
         <note annotates="source" from="developer">%1 is the name of the device being removed. The name is displayed on purpose on a new line.</note>
       </trans-unit>
       <trans-unit id="vpn.devices.cancelDeviceRemoval">
         <source xml:space="preserve">Cancel</source>
-        <target xml:space="preserve">Annulla</target>
+        <target>Annulla</target>
       </trans-unit>
       <trans-unit id="vpn.devices.removeDeviceButton">
         <source xml:space="preserve">Remove</source>
-        <target xml:space="preserve">Rimuovi</target>
+        <target>Rimuovi</target>
         <note annotates="source" from="developer">This is the “remove” device button.</note>
       </trans-unit>
     </body>
@@ -247,7 +247,7 @@
     <body>
       <trans-unit id="cities">
         <source xml:space="preserve">Cities</source>
-        <target xml:space="preserve">Città</target>
+        <target>Città</target>
         <note annotates="source" from="developer">The title for the list of cities.</note>
       </trans-unit>
     </body>
@@ -256,7 +256,7 @@
     <body>
       <trans-unit id="vpn.main.signOut">
         <source xml:space="preserve">Sign Out</source>
-        <target xml:space="preserve">Disconnetti</target>
+        <target>Disconnetti</target>
       </trans-unit>
     </body>
   </file>
@@ -264,12 +264,12 @@
     <body>
       <trans-unit id="vpn.connectionStability.unstable">
         <source xml:space="preserve">Unstable</source>
-        <target xml:space="preserve">Non stabile</target>
+        <target>Non stabile</target>
         <note annotates="source" from="developer">This refers to the user’s internet connection.</note>
       </trans-unit>
       <trans-unit id="vpn.connectionStability.noSignal">
         <source xml:space="preserve">No Signal</source>
-        <target xml:space="preserve">Nessun segnale</target>
+        <target>Nessun segnale</target>
       </trans-unit>
     </body>
   </file>
@@ -277,36 +277,36 @@
     <body>
       <trans-unit id="vpn.alert.authenticationError">
         <source xml:space="preserve">Authentication error</source>
-        <target xml:space="preserve">Errore durante l’autenticazione</target>
+        <target>Errore durante l’autenticazione</target>
       </trans-unit>
       <trans-unit id="vpn.alert.tryAgain">
         <source xml:space="preserve">Try again</source>
-        <target xml:space="preserve">Riprova</target>
+        <target>Riprova</target>
       </trans-unit>
       <trans-unit id="vpn.alert.unableToConnect">
         <source xml:space="preserve">Unable to connect</source>
-        <target xml:space="preserve">Connessione non riuscita</target>
+        <target>Connessione non riuscita</target>
       </trans-unit>
       <trans-unit id="vpn.alert.noInternet">
         <source xml:space="preserve">No internet connection</source>
-        <target xml:space="preserve">Nessuna connessione a Internet</target>
+        <target>Nessuna connessione a Internet</target>
       </trans-unit>
       <trans-unit id="vpn.alert.backgroundServiceError">
         <source xml:space="preserve">Background service error</source>
-        <target xml:space="preserve">Errore del servizio in background</target>
+        <target>Errore del servizio in background</target>
       </trans-unit>
       <trans-unit id="vpn.alert.restore">
         <source xml:space="preserve">Restore</source>
-        <target xml:space="preserve">Ripristina</target>
+        <target>Ripristina</target>
         <note annotates="source" from="developer">Restore a service in case of error.</note>
       </trans-unit>
       <trans-unit id="vpn.alert.subscriptionFailureError">
         <source xml:space="preserve">Subscription failed</source>
-        <target xml:space="preserve">Abbonamento non completato</target>
+        <target>Abbonamento non completato</target>
       </trans-unit>
       <trans-unit id="vpn.alert.deviceRemovedAndLogout">
         <source xml:space="preserve">Signed out and device removed</source>
-        <target xml:space="preserve">Disconnessione effettuata e dispositivo rimosso</target>
+        <target>Disconnessione effettuata e dispositivo rimosso</target>
       </trans-unit>
     </body>
   </file>
@@ -314,11 +314,11 @@
     <body>
       <trans-unit id="vpn.toggle.on">
         <source xml:space="preserve">Turn VPN on</source>
-        <target xml:space="preserve">Attiva VPN</target>
+        <target>Attiva VPN</target>
       </trans-unit>
       <trans-unit id="vpn.toggle.off">
         <source xml:space="preserve">Turn VPN off</source>
-        <target xml:space="preserve">Disattiva VPN</target>
+        <target>Disattiva VPN</target>
       </trans-unit>
     </body>
   </file>
@@ -326,21 +326,21 @@
     <body>
       <trans-unit id="vpn.settings.language">
         <source xml:space="preserve">Language</source>
-        <target xml:space="preserve">Lingua</target>
+        <target>Lingua</target>
       </trans-unit>
       <trans-unit id="vpn.settings.system">
         <source xml:space="preserve">System</source>
-        <target xml:space="preserve">Sistema</target>
+        <target>Sistema</target>
         <note annotates="source" from="developer">Language of the system.</note>
       </trans-unit>
       <trans-unit id="vpn.settings.languageAccessibleName">
         <source xml:space="preserve">%1 %2</source>
-        <target xml:space="preserve">%1 %2</target>
+        <target>%1 %2</target>
         <note annotates="source" from="developer">This string is read by accessibility tools. %1 is the language name, %2 is the localized language name.</note>
       </trans-unit>
       <trans-unit id="vpn.settings.additional">
         <source xml:space="preserve">Additional</source>
-        <target xml:space="preserve">Altre lingue</target>
+        <target>Altre lingue</target>
         <note annotates="source" from="developer">Header for the additional languages in settings</note>
       </trans-unit>
     </body>
@@ -349,23 +349,23 @@
     <body>
       <trans-unit id="vpn.settings.networking">
         <source xml:space="preserve">Network settings</source>
-        <target xml:space="preserve">Impostazioni di rete</target>
+        <target>Impostazioni di rete</target>
       </trans-unit>
       <trans-unit id="vpn.settings.ipv6">
         <source xml:space="preserve">IPv6</source>
-        <target xml:space="preserve">IPv6</target>
+        <target>IPv6</target>
       </trans-unit>
       <trans-unit id="vpn.settings.ipv6.description">
         <source xml:space="preserve">Push the internet forward with the latest version of the Internet Protocol</source>
-        <target xml:space="preserve">Contribuisci al progresso di internet utilizzando la versione più recente del protocollo internet.</target>
+        <target>Contribuisci al progresso di internet utilizzando la versione più recente del protocollo internet.</target>
       </trans-unit>
       <trans-unit id="vpn.settings.lanAccess">
         <source xml:space="preserve">Local network access</source>
-        <target xml:space="preserve">Accesso alla rete locale</target>
+        <target>Accesso alla rete locale</target>
       </trans-unit>
       <trans-unit id="vpn.settings.lanAccess.description">
         <source xml:space="preserve">Access printers, streaming sticks and all other devices on your local network</source>
-        <target xml:space="preserve">Accedi a stampanti, chiavette per lo streaming e tutti gli altri dispositivi sulla tua rete locale</target>
+        <target>Accedi a stampanti, chiavette per lo streaming e tutti gli altri dispositivi sulla tua rete locale</target>
       </trans-unit>
     </body>
   </file>
@@ -373,15 +373,15 @@
     <body>
       <trans-unit id="vpn.settings.notifications">
         <source xml:space="preserve">Notifications</source>
-        <target xml:space="preserve">Notifiche</target>
+        <target>Notifiche</target>
       </trans-unit>
       <trans-unit id="vpn.settings.guestWifiAlert">
         <source xml:space="preserve">Guest Wi-Fi portal alert</source>
-        <target xml:space="preserve">Avviso portale Wi-Fi per ospiti</target>
+        <target>Avviso portale Wi-Fi per ospiti</target>
       </trans-unit>
       <trans-unit id="vpn.settings.guestWifiAlert.description">
         <source xml:space="preserve">Get notified if a guest Wi-Fi portal is blocked due to VPN connection</source>
-        <target xml:space="preserve">Ricevi una notifica se un portale Wi-Fi è bloccato dalla connessione VPN</target>
+        <target>Ricevi una notifica se un portale Wi-Fi è bloccato dalla connessione VPN</target>
       </trans-unit>
     </body>
   </file>
@@ -389,19 +389,19 @@
     <body>
       <trans-unit id="vpn.settings.giveFeedback">
         <source xml:space="preserve">Give feedback</source>
-        <target xml:space="preserve">Invia feedback</target>
+        <target>Invia feedback</target>
       </trans-unit>
       <trans-unit id="vpn.settings.user">
         <source xml:space="preserve">VPN User</source>
-        <target xml:space="preserve">Utente VPN</target>
+        <target>Utente VPN</target>
       </trans-unit>
       <trans-unit id="vpn.main.manageAccount">
         <source xml:space="preserve">Manage account</source>
-        <target xml:space="preserve">Gestisci account</target>
+        <target>Gestisci account</target>
       </trans-unit>
       <trans-unit id="vpn.settings.runOnBoot">
         <source xml:space="preserve">Launch VPN app on Startup</source>
-        <target xml:space="preserve">Apri l’app VPN all'avvio</target>
+        <target>Apri l’app VPN all'avvio</target>
       </trans-unit>
     </body>
   </file>
@@ -409,7 +409,7 @@
     <body>
       <trans-unit id="vpn.authenticating.waitForSignIn">
         <source xml:space="preserve">Waiting for sign in and subscription confirmation…</source>
-        <target xml:space="preserve">In attesa dell’accesso e della conferma dell’abbonamento…</target>
+        <target>In attesa dell’accesso e della conferma dell’abbonamento…</target>
       </trans-unit>
     </body>
   </file>
@@ -417,15 +417,15 @@
     <body>
       <trans-unit id="vpn.postAuthentication..quickAccess">
         <source xml:space="preserve">Quick access</source>
-        <target xml:space="preserve">Accesso rapido</target>
+        <target>Accesso rapido</target>
       </trans-unit>
       <trans-unit id="vpn.postAuthentication.statusBarIntro">
         <source xml:space="preserve">You can quickly access Mozilla VPN from your status bar.</source>
-        <target xml:space="preserve">È possibile accedere rapidamente a Mozilla VPN dalla barra di stato.</target>
+        <target>È possibile accedere rapidamente a Mozilla VPN dalla barra di stato.</target>
       </trans-unit>
       <trans-unit id="vpn.postAuthentication.continue">
         <source xml:space="preserve">Continue</source>
-        <target xml:space="preserve">Continua</target>
+        <target>Continua</target>
       </trans-unit>
     </body>
   </file>
@@ -433,7 +433,7 @@
     <body>
       <trans-unit id="vpn.subscription.waitForValidation">
         <source xml:space="preserve">Confirming subscription…</source>
-        <target xml:space="preserve">Conferma abbonamento…</target>
+        <target>Conferma abbonamento…</target>
       </trans-unit>
     </body>
   </file>
@@ -441,30 +441,30 @@
     <body>
       <trans-unit id="vpn.devices.deviceAccessibleName">
         <source xml:space="preserve">%1 %2</source>
-        <target xml:space="preserve">%1 %2</target>
+        <target>%1 %2</target>
         <note annotates="source" from="developer">Example: "deviceName deviceDescription"</note>
       </trans-unit>
       <trans-unit id="vpn.devices.currentDevice">
         <source xml:space="preserve">Current Device</source>
-        <target xml:space="preserve">Dispositivo corrente</target>
+        <target>Dispositivo corrente</target>
       </trans-unit>
       <trans-unit id="vpn.devices.addedltHour">
         <source xml:space="preserve">Added less than an hour ago</source>
-        <target xml:space="preserve">Aggiunto meno di un’ora fa</target>
+        <target>Aggiunto meno di un’ora fa</target>
       </trans-unit>
       <trans-unit id="vpn.devices.addedXhoursAgo">
         <source xml:space="preserve">Added a few hours ago (%1)</source>
-        <target xml:space="preserve">Aggiunto alcune ore fa (%1)</target>
+        <target>Aggiunto alcune ore fa (%1)</target>
         <note annotates="source" from="developer">%1 is the number of hours.</note>
       </trans-unit>
       <trans-unit id="vpn.devices.addedXdaysAgo">
         <source xml:space="preserve">Added %1 days ago</source>
-        <target xml:space="preserve">Aggiunto %1 giorni fa</target>
+        <target>Aggiunto %1 giorni fa</target>
         <note annotates="source" from="developer">%1 is the number of days. Note: there is currently no support for proper plurals</note>
       </trans-unit>
       <trans-unit id="vpn.devices.removeA11Y">
         <source xml:space="preserve">Remove %1</source>
-        <target xml:space="preserve">Rimuovi %1</target>
+        <target>Rimuovi %1</target>
         <note annotates="source" from="developer">Label used for accessibility on the button to remove a device. %1 is the name of the device.</note>
       </trans-unit>
     </body>
@@ -473,11 +473,11 @@
     <body>
       <trans-unit id="vpn.main.getStarted">
         <source xml:space="preserve">Get started</source>
-        <target xml:space="preserve">Per iniziare</target>
+        <target>Per iniziare</target>
       </trans-unit>
       <trans-unit id="vpn.main.learnMore">
         <source xml:space="preserve">Learn more</source>
-        <target xml:space="preserve">Ulteriori informazioni</target>
+        <target>Ulteriori informazioni</target>
       </trans-unit>
     </body>
   </file>
@@ -485,19 +485,19 @@
     <body>
       <trans-unit id="vpn.viewlogs.title">
         <source xml:space="preserve">View Logs</source>
-        <target xml:space="preserve">Visualizza log</target>
+        <target>Visualizza log</target>
       </trans-unit>
       <trans-unit id="vpn.logs.copy">
         <source xml:space="preserve">Copy</source>
-        <target xml:space="preserve">Copia</target>
+        <target>Copia</target>
       </trans-unit>
       <trans-unit id="vpn.logs.copied">
         <source xml:space="preserve">Copied!</source>
-        <target xml:space="preserve">Copiato.</target>
+        <target>Copiato.</target>
       </trans-unit>
       <trans-unit id="vpn.logs.clear">
         <source xml:space="preserve">Clear</source>
-        <target xml:space="preserve">Cancella</target>
+        <target>Cancella</target>
       </trans-unit>
     </body>
   </file>
@@ -505,15 +505,15 @@
     <body>
       <trans-unit id="MozillaVPN">
         <source xml:space="preserve">Mozilla VPN</source>
-        <target xml:space="preserve">Mozilla VPN</target>
+        <target>Mozilla VPN</target>
       </trans-unit>
       <trans-unit id="vpn.updates.newVersionAvailable">
         <source xml:space="preserve">New version is available.</source>
-        <target xml:space="preserve">È disponibile una nuova versione.</target>
+        <target>È disponibile una nuova versione.</target>
       </trans-unit>
       <trans-unit id="vpn.updates.updateNow">
         <source xml:space="preserve">Update now</source>
-        <target xml:space="preserve">Aggiorna adesso</target>
+        <target>Aggiorna adesso</target>
       </trans-unit>
     </body>
   </file>
@@ -521,44 +521,44 @@
     <body>
       <trans-unit id="vpn.onboarding.headline.1">
         <source xml:space="preserve">Device-level encryption</source>
-        <target xml:space="preserve">Crittografia per l’intero dispositivo</target>
+        <target>Crittografia per l’intero dispositivo</target>
       </trans-unit>
       <trans-unit id="vpn.onboarding.subtitle.1">
         <source xml:space="preserve">Encrypt your traffic so that it can’t be read by your ISP or eavesdroppers.</source>
-        <target xml:space="preserve">Impedisci al tuo fornitore di accesso a Internet e altri soggetti di analizzare il tuo traffico dati.</target>
+        <target>Impedisci al tuo fornitore di accesso a Internet e altri soggetti di analizzare il tuo traffico dati.</target>
       </trans-unit>
       <trans-unit id="vpn.onboarding.headline.2">
         <source xml:space="preserve">Servers in 30+ countries</source>
-        <target xml:space="preserve">Server in oltre 30 Paesi</target>
+        <target>Server in oltre 30 Paesi</target>
         <note annotates="source" from="developer">The + after the number stands for “more than”. If you change the number of countries here, please update ViewSubscriptionNeeded.qml too.</note>
       </trans-unit>
       <trans-unit id="vpn.onboarding.subtitle.2">
         <source xml:space="preserve">Pick a server in any country you want and hide your location to throw off trackers.</source>
-        <target xml:space="preserve">Scegli un server nel Paese che desideri e nascondi la tua posizione per proteggerti dal tracciamento.</target>
+        <target>Scegli un server nel Paese che desideri e nascondi la tua posizione per proteggerti dal tracciamento.</target>
       </trans-unit>
       <trans-unit id="vpn.onboarding.headline.3">
         <source xml:space="preserve">No bandwidth restrictions</source>
-        <target xml:space="preserve">Nessuna limitazione alla larghezza di banda</target>
+        <target>Nessuna limitazione alla larghezza di banda</target>
       </trans-unit>
       <trans-unit id="vpn.onboarding.subtitle.3">
         <source xml:space="preserve">Stream, download, and game without limits, monthly caps or ISP throttling.</source>
-        <target xml:space="preserve">Riproduci contenuti in streaming, scarica e gioca senza blocchi, limiti mensili o limitazioni da parte del tuo fornitore di accesso a Internet.</target>
+        <target>Riproduci contenuti in streaming, scarica e gioca senza blocchi, limiti mensili o limitazioni da parte del tuo fornitore di accesso a Internet.</target>
       </trans-unit>
       <trans-unit id="vpn.onboarding.headline.4">
         <source xml:space="preserve">No online activity logs</source>
-        <target xml:space="preserve">Nessun registro delle tue attività online</target>
+        <target>Nessun registro delle tue attività online</target>
       </trans-unit>
       <trans-unit id="vpn.onboarding.subtitle.4">
         <source xml:space="preserve">We are committed to not monitoring or logging your browsing or network history.</source>
-        <target xml:space="preserve">Ci impegniamo a non monitorare o registrare la cronologia di navigazione o di rete.</target>
+        <target>Ci impegniamo a non monitorare o registrare la cronologia di navigazione o di rete.</target>
       </trans-unit>
       <trans-unit id="vpn.onboarding.skip">
         <source xml:space="preserve">Skip</source>
-        <target xml:space="preserve">Ignora</target>
+        <target>Ignora</target>
       </trans-unit>
       <trans-unit id="vpn.onboarding.next">
         <source xml:space="preserve">Next</source>
-        <target xml:space="preserve">Successivo</target>
+        <target>Successivo</target>
       </trans-unit>
     </body>
   </file>
@@ -566,54 +566,54 @@
     <body>
       <trans-unit id="vpn.subscription.title">
         <source xml:space="preserve">Subscribe for %1/mo</source>
-        <target xml:space="preserve">Abbonati per %1 al mese</target>
+        <target>Abbonati per %1 al mese</target>
         <note annotates="source" from="developer">“/mo” stands for “per month”. %1 is replaced by the cost (including currency).</note>
       </trans-unit>
       <trans-unit id="vpn.subscription.moneyBackGuarantee">
         <source xml:space="preserve">30-day money-back guarantee</source>
-        <target xml:space="preserve">Garanzia di rimborso di 30 giorni</target>
+        <target>Garanzia di rimborso di 30 giorni</target>
       </trans-unit>
       <trans-unit id="vpn.subscription.featureTitle1">
         <source xml:space="preserve">No activity logs</source>
-        <target xml:space="preserve">Nessun registro delle attività</target>
+        <target>Nessun registro delle attività</target>
       </trans-unit>
       <trans-unit id="vpn.subscription.featureSubtitle1">
         <source xml:space="preserve">We’re Mozilla. We’re on your side.</source>
-        <target xml:space="preserve">Siamo Mozilla. Siamo dalla tua parte.</target>
+        <target>Siamo Mozilla. Siamo dalla tua parte.</target>
       </trans-unit>
       <trans-unit id="vpn.subscription.featureTitle2">
         <source xml:space="preserve">No one can track you</source>
-        <target xml:space="preserve">Nessuno può tracciarti</target>
+        <target>Nessuno può tracciarti</target>
       </trans-unit>
       <trans-unit id="vpn.subscription.featureSubtitle2">
         <source xml:space="preserve">We encrypt your entire device.</source>
-        <target xml:space="preserve">Proteggiamo il tuo intero dispositivo.</target>
+        <target>Proteggiamo il tuo intero dispositivo.</target>
       </trans-unit>
       <trans-unit id="vpn.subscription.featureTitle3">
         <source xml:space="preserve">360+ servers in 30+ countries</source>
-        <target xml:space="preserve">Oltre 360 server in più di 30 Paesi.</target>
+        <target>Oltre 360 server in più di 30 Paesi.</target>
         <note annotates="source" from="developer">The + after each number stands for “more than”. If you change the number of countries here, please update ViewOnboarding.qml too.</note>
       </trans-unit>
       <trans-unit id="vpn.subscription.featureSubtitle3">
         <source xml:space="preserve">Protect your access to the web.</source>
-        <target xml:space="preserve">Proteggi il tuo accesso al Web.</target>
+        <target>Proteggi il tuo accesso al Web.</target>
       </trans-unit>
       <trans-unit id="vpn.subscription.featureTitle4">
         <source xml:space="preserve">Connect up to %1 devices</source>
-        <target xml:space="preserve">Connetti fino a %1 dispositivi</target>
+        <target>Connetti fino a %1 dispositivi</target>
         <note annotates="source" from="developer">%1 is the number of devices. Note: there is currently no support for proper plurals</note>
       </trans-unit>
       <trans-unit id="vpn.subscription.featureSubtitle4">
         <source xml:space="preserve">We won’t restrict your bandwidth.</source>
-        <target xml:space="preserve">Non limiteremo la tua larghezza di banda.</target>
+        <target>Non limiteremo la tua larghezza di banda.</target>
       </trans-unit>
       <trans-unit id="vpn.updates.subscribeNow">
         <source xml:space="preserve">Subscribe now</source>
-        <target xml:space="preserve">Abbonati adesso</target>
+        <target>Abbonati adesso</target>
       </trans-unit>
       <trans-unit id="vpn.main.restorePurchases">
         <source xml:space="preserve">Restore purchases</source>
-        <target xml:space="preserve">Ripristina aquisti</target>
+        <target>Ripristina aquisti</target>
       </trans-unit>
     </body>
   </file>
@@ -621,27 +621,27 @@
     <body>
       <trans-unit id="vpn.updates.updateRecomended">
         <source xml:space="preserve">Update recommended</source>
-        <target xml:space="preserve">Aggiornamento consigliato</target>
+        <target>Aggiornamento consigliato</target>
       </trans-unit>
       <trans-unit id="vpn.updates.updateRecomended.description">
         <source xml:space="preserve">Please update the app before you continue to use the VPN</source>
-        <target xml:space="preserve">Aggiornare l’app prima di continuare a utilizzare la VPN</target>
+        <target>Aggiornare l’app prima di continuare a utilizzare la VPN</target>
       </trans-unit>
       <trans-unit id="vpn.updates.updateRequired">
         <source xml:space="preserve">Update required</source>
-        <target xml:space="preserve">Aggiornamento richiesto</target>
+        <target>Aggiornamento richiesto</target>
       </trans-unit>
       <trans-unit id="vpn.updates.updateRequire.reason">
         <source xml:space="preserve">We detected and fixed a serious bug. You must update your app.</source>
-        <target xml:space="preserve">Abbiamo identificato e risolto un problema grave. È necessario aggiornare l’app.</target>
+        <target>Abbiamo identificato e risolto un problema grave. È necessario aggiornare l’app.</target>
       </trans-unit>
       <trans-unit id="vpn.updates.updateConnectionInsecureWarning">
         <source xml:space="preserve">Your connection will not be secure while you update.</source>
-        <target xml:space="preserve">La connessione non sarà sicura durante l'aggiornamento.</target>
+        <target>La connessione non sarà sicura durante l'aggiornamento.</target>
       </trans-unit>
       <trans-unit id="vpn.updates.notNow">
         <source xml:space="preserve">Not now</source>
-        <target xml:space="preserve">Non adesso</target>
+        <target>Non adesso</target>
       </trans-unit>
     </body>
   </file>
@@ -649,7 +649,7 @@
     <body>
       <trans-unit id="vpn.connectionInfo.unknown">
         <source xml:space="preserve">Unknown</source>
-        <target xml:space="preserve">sconosciuto</target>
+        <target>sconosciuto</target>
         <note annotates="source" from="developer">This refers to the current IP address, i.e. "IP: Unknown".</note>
       </trans-unit>
     </body>
@@ -658,15 +658,15 @@
     <body>
       <trans-unit id="help.viewLog">
         <source xml:space="preserve">View log</source>
-        <target xml:space="preserve">Visualizza log</target>
+        <target>Visualizza log</target>
       </trans-unit>
       <trans-unit id="help.helpCenter">
         <source xml:space="preserve">Help Center</source>
-        <target xml:space="preserve">Centro assistenza</target>
+        <target>Centro assistenza</target>
       </trans-unit>
       <trans-unit id="help.contactUs">
         <source xml:space="preserve">Contact us</source>
-        <target xml:space="preserve">Contattaci</target>
+        <target>Contattaci</target>
       </trans-unit>
     </body>
   </file>
@@ -674,29 +674,29 @@
     <body>
       <trans-unit id="vpn.systray.statusConnected.title">
         <source xml:space="preserve">VPN Connected</source>
-        <target xml:space="preserve">VPN connessa</target>
+        <target>VPN connessa</target>
       </trans-unit>
       <trans-unit id="vpn.systray.statusConnected.message">
         <source xml:space="preserve">Connected to %1, %2</source>
-        <target xml:space="preserve">Connessa con %1 (%2)</target>
+        <target>Connessa con %1 (%2)</target>
         <note annotates="source" from="developer">Shown as message body in a notification. %1 is the country, %2 is the city.</note>
       </trans-unit>
       <trans-unit id="vpn.systray.statusDisconnected.title">
         <source xml:space="preserve">VPN Disconnected</source>
-        <target xml:space="preserve">VPN disconnessa</target>
+        <target>VPN disconnessa</target>
       </trans-unit>
       <trans-unit id="vpn.systray.statusDisconnected.message">
         <source xml:space="preserve">Disconnected from to %1, %2</source>
-        <target xml:space="preserve">Disconnessa da %1 (%2)</target>
+        <target>Disconnessa da %1 (%2)</target>
         <note annotates="source" from="developer">Shown as message body in a notification. %1 is the country, %2 is the city.</note>
       </trans-unit>
       <trans-unit id="vpn.systray.statusSwitch.title">
         <source xml:space="preserve">VPN Switched Servers</source>
-        <target xml:space="preserve">La VPN è passata a un altro server</target>
+        <target>La VPN è passata a un altro server</target>
       </trans-unit>
       <trans-unit id="vpn.systray.statusSwtich.message">
         <source xml:space="preserve">Switched from %1, %2 to %3, %4</source>
-        <target xml:space="preserve">Passaggio da %1 (%2) a %3 (%4)</target>
+        <target>Passaggio da %1 (%2) a %3 (%4)</target>
         <note annotates="source" from="developer">Shown as message body in a notification. %1 and %3 are countries, %2 and %4 are cities.</note>
       </trans-unit>
     </body>
@@ -714,15 +714,15 @@
     <body>
       <trans-unit id="menubar.file.title">
         <source xml:space="preserve">File</source>
-        <target xml:space="preserve">File</target>
+        <target>File</target>
       </trans-unit>
       <trans-unit id="menubar.file.close">
         <source xml:space="preserve">Close</source>
-        <target xml:space="preserve">Chiudi</target>
+        <target>Chiudi</target>
       </trans-unit>
       <trans-unit id="menubar.help.title">
         <source xml:space="preserve">Help</source>
-        <target xml:space="preserve">Aiuto</target>
+        <target>Aiuto</target>
       </trans-unit>
     </body>
   </file>
@@ -730,56 +730,56 @@
     <body>
       <trans-unit id="vpn.systray.status.connectedTo">
         <source xml:space="preserve">Connected to:</source>
-        <target xml:space="preserve">Connessa con:</target>
+        <target>Connessa con:</target>
       </trans-unit>
       <trans-unit id="vpn.systray.status.connectTo">
         <source xml:space="preserve">Connect to the last location:</source>
-        <target xml:space="preserve">Connetti con l’ultima posizione:</target>
+        <target>Connetti con l’ultima posizione:</target>
       </trans-unit>
       <trans-unit id="vpn.systray.status.connectingTo">
         <source xml:space="preserve">Connecting to:</source>
-        <target xml:space="preserve">Connessione in corso con:</target>
+        <target>Connessione in corso con:</target>
       </trans-unit>
       <trans-unit id="vpn.systray.status.disconnectingFrom">
         <source xml:space="preserve">Disconnecting from:</source>
-        <target xml:space="preserve">Disconnessione in corso da:</target>
+        <target>Disconnessione in corso da:</target>
       </trans-unit>
       <trans-unit id="vpn.systray.location">
         <source xml:space="preserve">%1, %2</source>
-        <target xml:space="preserve">%1 (%2)</target>
+        <target>%1 (%2)</target>
         <note annotates="source" from="developer">Location in the systray. %1 is the country, %2 is the city.</note>
       </trans-unit>
       <trans-unit id="systray.hide">
         <source xml:space="preserve">Hide Mozilla VPN</source>
-        <target xml:space="preserve">Nascondi Mozilla VPN</target>
+        <target>Nascondi Mozilla VPN</target>
       </trans-unit>
       <trans-unit id="systray.show">
         <source xml:space="preserve">Show Mozilla VPN</source>
-        <target xml:space="preserve">Mostra Mozilla VPN</target>
+        <target>Mostra Mozilla VPN</target>
       </trans-unit>
       <trans-unit id="vpn.systray.captivePortalAlert.title">
         <source xml:space="preserve">Captive portal detected</source>
-        <target xml:space="preserve">Rilevato captive portal</target>
+        <target>Rilevato captive portal</target>
       </trans-unit>
       <trans-unit id="vpn.systray.captivePortalAlert.message">
         <source xml:space="preserve">VPN will automatically reconnect when ready</source>
-        <target xml:space="preserve">La VPN si riconnetterà automaticamente non appena possibile</target>
+        <target>La VPN si riconnetterà automaticamente non appena possibile</target>
       </trans-unit>
       <trans-unit id="systray.disconnect">
         <source xml:space="preserve">Disconnect</source>
-        <target xml:space="preserve">Disconnetti</target>
+        <target>Disconnetti</target>
       </trans-unit>
       <trans-unit id="systray.help">
         <source xml:space="preserve">Help</source>
-        <target xml:space="preserve">Aiuto</target>
+        <target>Aiuto</target>
       </trans-unit>
       <trans-unit id="systray.preferences">
         <source xml:space="preserve">Preferences…</source>
-        <target xml:space="preserve">Preferenze…</target>
+        <target>Preferenze…</target>
       </trans-unit>
       <trans-unit id="systray.quit">
         <source xml:space="preserve">Quit Mozilla VPN</source>
-        <target xml:space="preserve">Esci da Mozilla VPN</target>
+        <target>Esci da Mozilla VPN</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
QT exports `<target>` elements with an `xml:space: preserve` attribute, but the [XLIFF 1.2 specs](http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html) expect that on the `<trans-unit>` element.

This would also clean up the diff created by the current update process.