### PR TITLE
Import strings generated from strings.yaml

### DIFF
--- a/.github/scripts/extract_source_strings.py
+++ b/.github/scripts/extract_source_strings.py
@@ -55,6 +55,16 @@ def main():
             file_name = f.get("original").replace("../../src/", "../src/")
             f.set("original", file_name)
 
+    # Normalize path for strings generated from strings.yaml, removing "../"
+    # (more than once if necessary).
+    for f in root.xpath("//x:file", namespaces=NS):
+        if "original" in f.attrib:
+            file_name = f.get("original")
+            if "l18nstrings_p.cpp" in file_name:
+                while file_name.startswith("../"):
+                    file_name = file_name.lstrip("../")
+                f.set("original", file_name)
+
     # Remove targets (i.e. translations) if present, since this is the reference
     # locale
     for target in root.xpath("//x:target", namespaces=NS):

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,2 +1,4 @@
-lxml==4.6.1
-translate-toolkit==3.3.2
+lxml==4.6.3
+pyhumps==3.0.2
+pyyaml==5.4.1
+translate-toolkit==3.3.6

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -34,8 +34,10 @@ jobs:
         run: |
           # Manually add QT executables to path
           export PATH=/opt/qt515/bin:$PATH
-          # Ensure that the folder to store the .ts file exists
+          # Ensure that the folder to store the .ts file exists, generate
+          # strings from strings.yaml
           mkdir -p vpn/translations/en
+          python vpn/scripts/generate_strings.py
           lupdate -version
           lupdate vpn/src/src.pro -ts
           # Store translations from the "main" branch in translations.ts
@@ -46,8 +48,13 @@ jobs:
             echo Importing strings from $branch
             cd vpn && git checkout $branch
             cd ..
-            # Ensure that the folder to store the .ts file exists
+            # Ensure that the folder to store the .ts file exists, generate
+            # strings from strings.yaml
             mkdir -p vpn/translations/en
+            if [ -f "vpn/scripts/generate_strings.py" ]
+            then
+              python vpn/scripts/generate_strings.py
+            fi
             lupdate vpn/src/src.pro -ts
             # Older branches can have mozillavpn_en.ts in a different path
             if [ -f "vpn/translations/en/mozillavpn_en.ts" ]


### PR DESCRIPTION
Will need to be tested properly once we have new strings in that file.

I decided to normalize the paths when creating the XLIFF (remove `../`), to avoid issues we had in the past (they depend on the position of the .ts file in the code repository).

For more details, see https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1331