### PR TITLE
Fix casing for several strings in en locales

### DIFF
--- a/en_CA/mozillavpn.xliff
+++ b/en_CA/mozillavpn.xliff
@@ -629,12 +629,12 @@
     <body>
       <trans-unit id="vpn.protectSelectedApps.addApplication" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
-        <target>Add Application</target>
+        <target>Add application</target>
         <source>Add Application</source>
       </trans-unit>
       <trans-unit id="vpn.protectSelectedApps.searchApps" xml:space="preserve">
         <note annotates="source" from="developer">Search bar placeholder text</note>
-        <target>Search Apps</target>
+        <target>Search apps</target>
         <source>Search Apps</source>
       </trans-unit>
       <trans-unit id="vpn.settings.appPermissions2" xml:space="preserve">
@@ -913,7 +913,7 @@
     <body>
       <trans-unit id="vpn.subscriptionBlocked.getHelp" xml:space="preserve">
         <source>Get Help</source>
-        <target>Get Help</target>
+        <target>Get help</target>
       </trans-unit>
       <trans-unit id="vpn.subscriptionBlocked.visitHelpCenter" xml:space="preserve">
         <source>Visit our help center to learn more about managing your subscriptions.</source>
@@ -1202,7 +1202,7 @@
       </trans-unit>
       <trans-unit id="vpn.feedbackForm.chooseCategory" xml:space="preserve">
         <source>Choose a category</source>
-        <target>Choose a Category</target>
+        <target>Choose a category</target>
       </trans-unit>
       <trans-unit id="vpn.feedbackForm.excellentLabel" xml:space="preserve">
         <note annotates="source" from="developer">One of the answers on the feedback question about the user experience with the VPN client.</note>

--- a/en_GB/mozillavpn.xliff
+++ b/en_GB/mozillavpn.xliff
@@ -629,12 +629,12 @@
     <body>
       <trans-unit id="vpn.protectSelectedApps.addApplication" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
-        <target>Add Application</target>
+        <target>Add application</target>
         <source>Add Application</source>
       </trans-unit>
       <trans-unit id="vpn.protectSelectedApps.searchApps" xml:space="preserve">
         <note annotates="source" from="developer">Search bar placeholder text</note>
-        <target>Search Apps</target>
+        <target>Search apps</target>
         <source>Search Apps</source>
       </trans-unit>
       <trans-unit id="vpn.settings.appPermissions2" xml:space="preserve">
@@ -913,7 +913,7 @@
     <body>
       <trans-unit id="vpn.subscriptionBlocked.getHelp" xml:space="preserve">
         <source>Get Help</source>
-        <target>Get Help</target>
+        <target>Get help</target>
       </trans-unit>
       <trans-unit id="vpn.subscriptionBlocked.visitHelpCenter" xml:space="preserve">
         <source>Visit our help center to learn more about managing your subscriptions.</source>
@@ -1203,7 +1203,7 @@
       </trans-unit>
       <trans-unit id="vpn.feedbackForm.chooseCategory" xml:space="preserve">
         <source>Choose a category</source>
-        <target>Choose a Category</target>
+        <target>Choose a category</target>
       </trans-unit>
       <trans-unit id="vpn.feedbackForm.excellentLabel" xml:space="preserve">
         <note annotates="source" from="developer">One of the answers on the feedback question about the user experience with the VPN client.</note>


### PR DESCRIPTION
This changes the casing of several strings in en locales.
Fixes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1858


Should the following lines (apologies that I seem to be unable to create embedded permalinks) be updated in the client code? And if so, will the `<source></source>` values for those strings need to be updated here/somewhere manually? 
- https://github.com/mozilla-mobile/mozilla-vpn-client/blob/f818b370c4a83e58a6067baf96b4c836d12559df/src/ui/settings/ViewAppPermissions.qml#L20
- https://github.com/mozilla-mobile/mozilla-vpn-client/blob/f818b370c4a83e58a6067baf96b4c836d12559df/src/ui/settings/ViewAppPermissions.qml#L24
- https://github.com/mozilla-mobile/mozilla-vpn-client/blob/f818b370c4a83e58a6067baf96b4c836d12559df/src/ui/states/StateSubscriptionBlocked.qml#L33
