### PR TITLE
Copy `servers.Malmö` translations to `servers.Malm`

### DIFF
--- a/bg/extras.xliff
+++ b/bg/extras.xliff
@@ -502,6 +502,10 @@
         <source>Malmö</source>
         <target>Малмьо</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Малмьо</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Стокхолм</target>

--- a/co/extras.xliff
+++ b/co/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stoccolma</target>

--- a/cs/extras.xliff
+++ b/cs/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/cy/extras.xliff
+++ b/cy/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/da/extras.xliff
+++ b/da/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmø</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmø</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/de/extras.xliff
+++ b/de/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/dsb/extras.xliff
+++ b/dsb/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/el/extras.xliff
+++ b/el/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Μάλμε</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Μάλμε</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Στοκχόλμη</target>

--- a/en/extras.xliff
+++ b/en/extras.xliff
@@ -381,6 +381,9 @@
       <trans-unit id="servers.Malmö" xml:space="preserve">
         <source>Malmö</source>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
       </trans-unit>

--- a/en_CA/extras.xliff
+++ b/en_CA/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/en_GB/extras.xliff
+++ b/en_GB/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/es_AR/extras.xliff
+++ b/es_AR/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmo</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmo</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Estocolmo</target>

--- a/es_CL/extras.xliff
+++ b/es_CL/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Estocolmo</target>

--- a/es_ES/extras.xliff
+++ b/es_ES/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Estocolmo</target>

--- a/es_MX/extras.xliff
+++ b/es_MX/extras.xliff
@@ -482,6 +482,9 @@
       <trans-unit id="servers.Malmö" xml:space="preserve">
         <source>Malmö</source>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Estocolmo</target>

--- a/fa/extras.xliff
+++ b/fa/extras.xliff
@@ -502,6 +502,10 @@
         <source>Malmö</source>
         <target>مالمو</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>مالمو</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>استکهلم</target>

--- a/fi/extras.xliff
+++ b/fi/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Tukholma</target>

--- a/fr/extras.xliff
+++ b/fr/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/fy_NL/extras.xliff
+++ b/fy_NL/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/hsb/extras.xliff
+++ b/hsb/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/hu/extras.xliff
+++ b/hu/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/ia/extras.xliff
+++ b/ia/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/id/extras.xliff
+++ b/id/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/is/extras.xliff
+++ b/is/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stokkhólmur</target>

--- a/it/extras.xliff
+++ b/it/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stoccolma</target>

--- a/ja/extras.xliff
+++ b/ja/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>マルメ</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>マルメ</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>ストックホルム</target>

--- a/lo/extras.xliff
+++ b/lo/extras.xliff
@@ -468,6 +468,9 @@
       <trans-unit id="servers.Malmö" xml:space="preserve">
         <source>Malmö</source>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
       </trans-unit>

--- a/nl/extras.xliff
+++ b/nl/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/oc/extras.xliff
+++ b/oc/extras.xliff
@@ -479,6 +479,9 @@
       <trans-unit id="servers.Malmö" xml:space="preserve">
         <source>Malmö</source>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Estocòlme</target>

--- a/pa_IN/extras.xliff
+++ b/pa_IN/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>ਮਾਲਮੋ</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>ਮਾਲਮੋ</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>ਸਟਾਕਹੋਮ</target>

--- a/pl/extras.xliff
+++ b/pl/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Sztokholm</target>

--- a/pt_BR/extras.xliff
+++ b/pt_BR/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Estocolmo</target>

--- a/pt_PT/extras.xliff
+++ b/pt_PT/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Estocolmo</target>

--- a/ru/extras.xliff
+++ b/ru/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Мальмё</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Мальмё</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Стокгольм</target>

--- a/sk/extras.xliff
+++ b/sk/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Štokholm</target>

--- a/sl/extras.xliff
+++ b/sl/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/sq/extras.xliff
+++ b/sq/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmo</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmo</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stokholmi</target>

--- a/sv_SE/extras.xliff
+++ b/sv_SE/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/tr/extras.xliff
+++ b/tr/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/uk/extras.xliff
+++ b/uk/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>Мальме</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Мальме</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Стокгольм</target>

--- a/zh_CN/extras.xliff
+++ b/zh_CN/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>马尔默</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>马尔默</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>斯德哥尔摩</target>

--- a/zh_TW/extras.xliff
+++ b/zh_TW/extras.xliff
@@ -506,6 +506,10 @@
         <source>Malmö</source>
         <target>馬爾摩</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>馬爾摩</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>斯德哥爾摩</target>


### PR DESCRIPTION
This is part of the work being done for VPN-6649 ticket. More details are available on https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10029.

This work consists of 3 PRs, to be merged in order:
1. This PR - copy all existing translations of Malmö from `servers.Malmö` to `servers.Malm`.
2. On the client repo: Adjusting the script when creating IDs for server translations (https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10029)
3. Another PR on this repo to remove all the legacy `servers.Malmö` translations strings.