### PR TITLE
Remove old `servers.Malmö` ids

### DIFF
--- a/bg/extras.xliff
+++ b/bg/extras.xliff
@@ -504,10 +504,6 @@
         <source>Gothenburg</source>
         <target>Гьотеборг</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Малмьо</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Малмьо</target>

--- a/co/extras.xliff
+++ b/co/extras.xliff
@@ -508,10 +508,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/cs/extras.xliff
+++ b/cs/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/cy/extras.xliff
+++ b/cy/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/da/extras.xliff
+++ b/da/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmø</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmø</target>

--- a/de/extras.xliff
+++ b/de/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/dsb/extras.xliff
+++ b/dsb/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/el/extras.xliff
+++ b/el/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Γκέτεμποργκ</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Μάλμε</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Μάλμε</target>

--- a/en/extras.xliff
+++ b/en/extras.xliff
@@ -384,9 +384,6 @@
       <trans-unit id="servers.Gothenburg" xml:space="preserve">
         <source>Gothenburg</source>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
       </trans-unit>

--- a/en_CA/extras.xliff
+++ b/en_CA/extras.xliff
@@ -508,10 +508,6 @@
         <source>Gothenburg</source>
         <target>Gothenburg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/en_GB/extras.xliff
+++ b/en_GB/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Gothenburg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/es_AR/extras.xliff
+++ b/es_AR/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Gotemburgo</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmo</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmo</target>

--- a/es_CL/extras.xliff
+++ b/es_CL/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Gotemburgo</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/es_ES/extras.xliff
+++ b/es_ES/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Gotemburgo</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/es_MX/extras.xliff
+++ b/es_MX/extras.xliff
@@ -508,10 +508,6 @@
         <source>Gothenburg</source>
         <target>Gotemburgo</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
       </trans-unit>

--- a/fa/extras.xliff
+++ b/fa/extras.xliff
@@ -504,10 +504,6 @@
         <source>Gothenburg</source>
         <target>یوتبری</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>مالمو</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>مالمو</target>

--- a/fi/extras.xliff
+++ b/fi/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/fr/extras.xliff
+++ b/fr/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/fy_NL/extras.xliff
+++ b/fy_NL/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Goateboarch</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/hsb/extras.xliff
+++ b/hsb/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/hu/extras.xliff
+++ b/hu/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/ia/extras.xliff
+++ b/ia/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/id/extras.xliff
+++ b/id/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/is/extras.xliff
+++ b/is/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Gautaborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/it/extras.xliff
+++ b/it/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/ja/extras.xliff
+++ b/ja/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>ヨーテボリ</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>マルメ</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>マルメ</target>

--- a/ko/extras.xliff
+++ b/ko/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>예테보리</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>말모어</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>말모어</target>

--- a/lo/extras.xliff
+++ b/lo/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Gothenburg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
       </trans-unit>

--- a/nl/extras.xliff
+++ b/nl/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/oc/extras.xliff
+++ b/oc/extras.xliff
@@ -482,9 +482,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
       </trans-unit>

--- a/pa_IN/extras.xliff
+++ b/pa_IN/extras.xliff
@@ -508,10 +508,6 @@
         <source>Gothenburg</source>
         <target>ਗੁਟਸਬਰਡ</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>ਮਾਲਮੋ</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>ਮਾਲਮੋ</target>

--- a/pl/extras.xliff
+++ b/pl/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/pt_BR/extras.xliff
+++ b/pt_BR/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Gotemburgo</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/pt_PT/extras.xliff
+++ b/pt_PT/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Gotemburgo</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/ru/extras.xliff
+++ b/ru/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Гётеборг</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Мальмё</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Мальмё</target>

--- a/sk/extras.xliff
+++ b/sk/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/sl/extras.xliff
+++ b/sl/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/sq/extras.xliff
+++ b/sq/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmo</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmo</target>

--- a/sv_SE/extras.xliff
+++ b/sv_SE/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/tr/extras.xliff
+++ b/tr/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Göteborg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Malmö</target>

--- a/uk/extras.xliff
+++ b/uk/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Гетеборг</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Мальме</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>Мальме</target>

--- a/vi/extras.xliff
+++ b/vi/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>Gothenburg</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>Malmö</target>
-      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>

--- a/zh_CN/extras.xliff
+++ b/zh_CN/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>哥德堡</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>马尔默</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>马尔默</target>

--- a/zh_TW/extras.xliff
+++ b/zh_TW/extras.xliff
@@ -510,10 +510,6 @@
         <source>Gothenburg</source>
         <target>哥特堡</target>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-        <target>馬爾摩</target>
-      </trans-unit>
       <trans-unit id="servers.Malm" xml:space="preserve">
         <source>Malmö</source>
         <target>馬爾摩</target>


### PR DESCRIPTION
This is part of the work being done for VPN-6649 ticket. More details are available on https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10029.

This work consists of 4 PRs, to be merged in order:
1. [An earlier PR](https://github.com/mozilla-l10n/mozilla-vpn-client-l10n/pull/488) on this repo - copied all existing translations of Malmö from `servers.Malmö` to `servers.Malm`.
2. A fixit PR on this repo: https://github.com/mozilla-l10n/mozilla-vpn-client-l10n/pull/490/files
3. On the client repo: Adjusting the script when creating IDs for server translations (https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10029)
4. This PR: remove all the legacy servers.Malmö translations strings.