### PR TITLE
Add `servers.Malm` for Vietnamese

### DIFF
--- a/vi/extras.xliff
+++ b/vi/extras.xliff
@@ -514,6 +514,10 @@
         <source>Malmö</source>
         <target>Malmö</target>
       </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
+        <target>Malmö</target>
+      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
         <target>Stockholm</target>


### PR DESCRIPTION
https://github.com/mozilla-l10n/mozilla-vpn-client-l10n/pull/488 was written using a fork of this repo, which today I realized was out of date. It was so out of date Vietnamese and Korean weren't in there, and thus I missed copying `servers.Malmö` to `servers.Malm` for these two languages.

Korean was already fixed (perhaps by a translator? sorry!) https://github.com/mozilla-l10n/mozilla-vpn-client-l10n/commit/1ed4613c2997585b5287dd2b8a5d220494509176 

This PR copies it over for Vietnamese.

(This is part of the work for VPN-6649.)