### PR TITLE
VPN-6749 - fix shared addon IDs

### DIFF
--- a/bg/addons/strings.xliff
+++ b/bg/addons/strings.xliff
@@ -2,31 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="bg">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>
       </trans-unit>

--- a/co/addons/strings.xliff
+++ b/co/addons/strings.xliff
@@ -2,31 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="co">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>
       </trans-unit>

--- a/cs/addons/strings.xliff
+++ b/cs/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Stáhnout aktualizaci</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Stáhněte si novou Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Tato aktualizace obsahuje drobné opravy chyb, úpravy uživatelského rozhraní a další vylepšení výkonu.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Získat pomoc</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Vydali jsme aktualizovanou verzi Mozilla VPN! Aktualizujte na nejnovější verzi a získejte nejlepší možnou zkušenost s Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Aktualizovat</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Aktualizace na Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/cy/addons/strings.xliff
+++ b/cy/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="cy">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Llwythwch y diweddariad i lawr</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Llwythwch i lawr y Mozilla VPN %1 newydd</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Mae'r diweddariad hwn yn cynnwys mân atgyweiriadau i fygiau, addasiadau UI a gwelliannau perfformiad eraill.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Derbyn cymorth</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Rydym wedi rhyddhau fersiwn wedi'i diweddaru o Mozilla VPN! Diweddarwch i'r fersiwn newydd i gael y profiad Mozilla VPN gorau posibl.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Diweddarwch nawr</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Diweddariad i Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/da/addons/strings.xliff
+++ b/da/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="da">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Hent opdatering</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Hent den nye Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Denne opdatering indeholder mindre fejlrettelser, justeringer af brugerfladen og andre forbedringer af ydelsen.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Få hjælp</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Vi har udgivet en opdateret version af Mozilla VPN! Opgrader til den seneste version for at få den bedst mulige oplevelse med Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Opdater nu</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Opdater til Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/de/addons/strings.xliff
+++ b/de/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="de">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Update herunterladen</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Laden Sie das neue Mozilla VPN %1 herunter</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Dieses Update enthält kleinere Fehlerbehebungen, Anpassungen der Benutzeroberfläche und andere Leistungsverbesserungen.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Unterstützung erhalten</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Wir haben eine aktualisierte Version von Mozilla VPN veröffentlicht! Aktualisieren Sie auf die neueste Version, um das bestmögliche Mozilla-VPN-Erlebnis zu erhalten.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Jetzt aktualisieren</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Aktualisieren Sie auf Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/dsb/addons/strings.xliff
+++ b/dsb/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="dsb">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Aktualizaciju ześěgnuś</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Nowy Mozilla VPN %1 ześěgnuś</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Toś ta aktualizacija mjeńše pórěźenja zmólkow, pśiměrjenja wužywaŕskego pówjercha a druge pólěpšenja wugbaśa wopśimujo.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Pomoc se wobstaraś</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Smy wózjawili zaktualizěrowanu wersiju Mozilla VPN! Aktualizěrujśo na nejnowšu wersiju za nejlěpše dožywjenje Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Něnto aktualizěrowaś</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Na Mozilla VPN %1 aktualizěrowaś</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/el/addons/strings.xliff
+++ b/el/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="el">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Λήψη ενημέρωσης</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Λήψη του νέου Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Αυτή η ενημέρωση περιλαμβάνει μικρές διορθώσεις σφαλμάτων, προσαρμογές στο περιβάλλον χρήστη και άλλες βελτιώσεις επιδόσεων.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Λήψη βοήθειας</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Έχουμε κυκλοφορήσει μια ενημερωμένη έκδοση του Mozilla VPN! Κάντε ενημέρωση στην πιο πρόσφατη έκδοση για τη βέλτιστη εμπειρία με το Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Ενημέρωση τώρα</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Ενημέρωση στο Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/en/addons/strings.xliff
+++ b/en/addons/strings.xliff
@@ -2,31 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="en">
     <body>
-      <trans-unit id="CommonStringsDownloadButton">
+      <trans-unit id="vpn.commonStrings.downloadButton">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle">
+      <trans-unit id="vpn.commonStrings.downloadTitle">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent">
         <note annotates="source" from="developer">Default update notes</note>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton">
+      <trans-unit id="vpn.commonStrings.getHelpButton">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle">
+      <trans-unit id="vpn.commonStrings.subtitle">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton">
+      <trans-unit id="vpn.commonStrings.updateButton">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle">
+      <trans-unit id="vpn.commonStrings.updateTitle">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>
       </trans-unit>

--- a/en_CA/addons/strings.xliff
+++ b/en_CA/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="en-CA">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Download update</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Download the new Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>This update includes minor bug fixes, UI adjustments and other performance improvements.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Get help</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Update now</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Update to Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/en_GB/addons/strings.xliff
+++ b/en_GB/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="en-GB">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Download update</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Download the new Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>This update includes minor bug fixes, UI adjustments and other performance improvements.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Get help</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Update now</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Update to Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/es_AR/addons/strings.xliff
+++ b/es_AR/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="es-AR">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Descargar actualización</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Descargá la nueva Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Esta actualización incluye correcciones de errores menores, ajustes de la interfaz de usuario y otras mejoras de rendimiento.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Obtener ayuda</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>¡Lanzamos una versión actualizada de Mozilla VPN! Actualizá a la última versión para tener la mejor experiencia posible con Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Actualizar ahora</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Actualizar a Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/es_CL/addons/strings.xliff
+++ b/es_CL/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="es-CL">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Bajar actualización</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Descarga el nuevo Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Esta actualización incluye correcciones de errores menores, ajustes de la interfaz de usuario y otras mejoras de rendimiento.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Obtener ayuda</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>¡Hemos lanzado una versión actualizada de Mozilla VPN! Actualice a la última versión para obtener la mejor experiencia posible de Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Actualizar ahora</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Actualizar a Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/es_ES/addons/strings.xliff
+++ b/es_ES/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="es-ES">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Descargar actualización</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Descarga el nuevo Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Esta actualización incluye correcciones de errores menores, ajustes de la interfaz de usuario y otras mejoras de rendimiento.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Obtener ayuda</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>¡Hemos lanzado una versión actualizada de Mozilla VPN! Actualiza a la última versión para la mejor experiencia de Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Actualizar ahora</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Actualizar a Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/es_MX/addons/strings.xliff
+++ b/es_MX/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="es-MX">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Descargar actualización</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Descarga la nueva Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Esta actualización incluye correcciones de errores menores, ajustes de la interfaz de usuario y otras mejoras de rendimiento.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Obtener ayuda</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>¡Hemos lanzado una versión actualizada de Mozilla VPN! Actualiza a la última versión para obtener la mejor experiencia posible de Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Actualizar ahora</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Actualizar a Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/fa/addons/strings.xliff
+++ b/fa/addons/strings.xliff
@@ -2,31 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="fa">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>
       </trans-unit>

--- a/fi/addons/strings.xliff
+++ b/fi/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="fi">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Lataa päivitys</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Lataa uusi Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Tämä päivitys sisältää pieniä virheenkorjauksia, käyttöliittymän säätöjä ja muita suorituskyvyn parannuksia.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Tuki</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Olemme julkaisseet päivitetyn version Mozilla VPN:stä! Päivitä uusimpaan versioon saadaksesi parhaan mahdollisen Mozilla VPN -kokemuksen.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Päivitä nyt</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Päivitä Mozilla VPN versioon %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/fr/addons/strings.xliff
+++ b/fr/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Télécharger la mise à jour</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Téléchargez la nouvelle version de Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Cette mise à jour comprend des corrections de bugs mineurs, des ajustements de l’interface et diverses améliorations des performances.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Obtenir de l’aide</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Nous avons publié une version mise à jour de Mozilla VPN ! Mettez à jour vers la dernière version pour bénéficier de la meilleure expérience Mozilla VPN possible.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Mettre à jour maintenant</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Mise à jour vers Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/fy_NL/addons/strings.xliff
+++ b/fy_NL/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="fy-NL">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Fernijing downloade</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Download de nije Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Dizze fernijing omfettet lytse bugfixes, oanpassingen yn de brûkersinterface en oare prestaasjesferbetteringen.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Help krije</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Wy hawwe in bywurke ferzje fan Mozilla VPN útbrocht! Wurkje by nei de nijste ferzje foar de bêst mooglike Mozilla VPN-ûnderfining.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>No bywurkje</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Bywurkje nei Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/hsb/addons/strings.xliff
+++ b/hsb/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="hsb">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Aktualizaciju sćahnyć</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Nowy Mozilla VPN %1 sćahnyć</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Tuta aktualizacija mjeńše porjedźenja zmylkow, přiměrjenja wužiwarskeho powjercha a druhe polěpšenja wukona wobsahuje.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Pomoc sej wobstarać</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Smy wózjawili zaktualizěrowanu wersiju Mozilla VPN! Aktualizěrujśo na nejnowšu wersiju za nejlěpše dožywjenje Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Nětko aktualizować</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Na Mozilla VPN %1 aktualizować</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/hu/addons/strings.xliff
+++ b/hu/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="hu">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Frissítés letöltése</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Megjelent az új Mozilla VPN %1, töltse le</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>A frissítés kisebb hibajavításokat, felületi módosításokat, és egyéb teljesítménybeli fejlesztéseket tartalmaz.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Segítség kérése</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Kiadtuk a Mozilla VPN frissített verzióját! Frissítsen a legújabb verzióra a lehető legjobb Mozilla VPN élményért.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Frissítés most</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Frissítés erre: Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/ia/addons/strings.xliff
+++ b/ia/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="ia">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Discargar actualisation</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Discarga le nove Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Iste actualisation include minor remedios de defecto, adjustamentos del interfacie de usator e altere meliorationes de prestation.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Obtener auxilio</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Nos ha publicate un version actualisate de Mozilla VPN! Actualisa al ultime version pro le melior experientia possibile de Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Actualisar ora</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Promover a Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/id/addons/strings.xliff
+++ b/id/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="id">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Unduh versi baru</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Unduh Mozilla VPN baru %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Pembaruan ini mencakup perbaikan bug minor, penyesuaian UI, dan peningkatan kinerja lainnya.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Dapatkan bantuan</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Kami telah merilis versi terbaru Mozilla VPN! Perbarui ke versi terbaru untuk pengalaman Mozilla VPN terbaik.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Perbarui sekarang</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Perbarui ke Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/is/addons/strings.xliff
+++ b/is/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="is">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Sækja uppfærslu</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Sæktu nýja Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Þessi uppfærsla inniheldur smávægilegar villuleiðréttingar, lagfæringar á notendaviðmóti og ýmsar endurbætur á afköstum.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Fá aðstoð</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Við höfum gefið út uppfærða útgáfu af Mozilla VPN! Uppfærðu í nýjustu útgáfuna til að fá sem besta upplifun af VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Uppfæra núna</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Uppfæra í Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/it/addons/strings.xliff
+++ b/it/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="it">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Scarica aggiornamento</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Scarica la nuova versione %1 di Mozilla VPN</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Questo aggiornamento include correzioni di bug secondari, modifiche dell’interfaccia utente e altri miglioramenti delle prestazioni.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Ottieni assistenza</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>È disponibile una versione aggiornata di Mozilla VPN! Esegui l’aggiornamento all’ultima versione per ottenere il massimo da Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Aggiorna adesso</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Aggiorna a Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/ja/addons/strings.xliff
+++ b/ja/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>更新をダウンロード</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>新しい Mozilla VPN %1 をダウンロード</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>この更新には、軽微なバグの修正、ユーザーインターフェース (UI) の調整およびその他のパフォーマンスの向上が含まれています。</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>ヘルプを表示</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Mozilla VPN の更新バージョンをリリースしました。最新バージョンに更新して Mozilla VPN のすばらしい機能を体験してください。</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>今すぐ更新</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Mozilla VPN %1 に更新</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/ko/addons/strings.xliff
+++ b/ko/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="ko">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>업데이트 다운로드</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>새로운 Mozilla VPN %1 다운로드</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>이 업데이트에는 사소한 버그 수정, UI 조정 및 기타 성능 향상이 포함됩니다.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>도움 받기</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>업데이트된 버전의 Mozilla VPN을 출시했습니다! 최상의 Mozilla VPN 경험을 위해 최신 버전으로 업데이트하세요.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>지금 업데이트하기</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Mozilla VPN %1로 업데이트</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/lo/addons/strings.xliff
+++ b/lo/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="lo">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>ດາວໂຫລດຕົວອັບເດດ</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>ດາວໂຫຼດ Mozilla VPN ໃໝ່ %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>ການປັບປຸງນີ້ປະກອບມີການແກ້ໄຂຂໍ້ຜິດພາດເລັກນ້ອຍ, ການປັບ UI ແລະ ການປັບປຸງປະສິດທິພາບອື່ນໆ.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>ຂໍຄວາມຊ່ວຍເຫລືອ</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>ພວກເຮົາໄດ້ປ່ອຍເວີຊັນອັບເດດຂອງ Mozilla VPN ແລ້ວ! ອັບເດດເປັນເວີຊັນຫຼ້າສຸດເພື່ອປະສົບການ Mozilla VPN ທີ່ດີທີ່ສຸດທີ່ເປັນໄປໄດ້.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>ອັບເດດຕອນນີ້</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>ອັບເດດເປັນ Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/nl/addons/strings.xliff
+++ b/nl/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Update downloaden</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Download de nieuwe Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Deze update bevat kleine bugfixes, aanpassingen in de gebruikersinterface en andere prestatieverbeteringen.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Hulp verkrijgen</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>We hebben een bijgewerkte versie van Mozilla VPN uitgebracht! Werk bij naar de nieuwste versie voor de best mogelijke Mozilla VPN-ervaring.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Nu bijwerken</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Bijwerken naar Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/oc/addons/strings.xliff
+++ b/oc/addons/strings.xliff
@@ -2,31 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="oc">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>
       </trans-unit>

--- a/pa_IN/addons/strings.xliff
+++ b/pa_IN/addons/strings.xliff
@@ -2,31 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="pa-IN">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>
       </trans-unit>

--- a/pl/addons/strings.xliff
+++ b/pl/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Pobierz aktualizację</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Pobierz nową wersję aplikacji Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Ta aktualizacja zawiera drobne poprawki błędów, korekty interfejsu użytkownika i ulepszenia wydajności.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Pomoc</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Wydaliśmy zaktualizowaną wersję Mozilla VPN! Zaktualizuj do najnowszej wersji, aby uzyskać najlepszą możliwą jakość działania Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Zaktualizuj teraz</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Aktualizacja Mozilli VPN do wersji %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/pt_BR/addons/strings.xliff
+++ b/pt_BR/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="pt-BR">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Baixar atualização</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Instale o novo Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Esta atualização contém pequenas correções, ajustes na interface do usuário e outras melhorias de desempenho.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Obter ajuda</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Lançamos uma nova versão do Mozilla VPN! Atualize para a versão mais recente, para ter a melhor experiência de uso possível do Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Atualizar agora</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Atualize para o Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/pt_PT/addons/strings.xliff
+++ b/pt_PT/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="pt-PT">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Transferir atualização</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Transferir a nova Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Esta atualização inclui pequenas correções de bugs, ajustes na interface do utilizador e outras melhorias de desempenho.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Obter ajuda</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Lançamos uma versão atualizada da Mozilla VPN! Atualize para a versão mais recente para obter a melhor experiência possível da Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Atualizar agora</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Atualizar para a Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/ru/addons/strings.xliff
+++ b/ru/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Загрузить обновление</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Загрузить новый Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Это обновление включает в себя незначительные исправления ошибок, изменения пользовательского интерфейса и другие улучшения производительности.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Получить помощь</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Мы выпустили обновленную версию Mozilla VPN! Обновитесь до последней версии, чтобы получить наилучшие возможности Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Обновить сейчас</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Обновить на Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/sk/addons/strings.xliff
+++ b/sk/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="sk">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Stiahnuť aktualizáciu</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Stiahnite si novú Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Táto aktualizácia obsahuje drobné opravy chýb, úpravy používateľského rozhrania a ďalšie vylepšenia výkonu.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Získať pomoc</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Sprístupnili sme aktualizovanú verziu Mozilla VPN! Aktualizujte na najnovšiu verziu a získate najlepší možný zážitok z Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Aktualizovať teraz</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Aktualizácia na Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/sl/addons/strings.xliff
+++ b/sl/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="sl">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Prenesi posodobitev</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Prenesite novi Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Ta posodobitev vključuje manjše popravke hroščev, prilagoditve uporabniškega vmesnika in druge izboljšave delovanja.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Pomoč</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Izdali smo posodobljeno različico Mozilla VPN! Za najboljšo možno izkušnjo nadgradite na najnovejšo različico.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Posodobi zdaj</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Posodobitev na Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/sq/addons/strings.xliff
+++ b/sq/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="sq">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Shkarkoje përditësimin</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Shkarkoni VPN e ri Mozilla %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Ky përditësim përfshin ndreqje të metash të vockla, përimtime të UI-t dhe të tjera përmirësime të funksionimit.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Merrni ndihmë</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Kemi hedhur në qarkullim një version të përditësuar të Mozilla VPN-së! Për punimin më të mirë të mundshëm të Mozilla VPN-së, përditësojeni me versionin më të ri.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Përditësojeni tani</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Përditësojeni me Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/sv_SE/addons/strings.xliff
+++ b/sv_SE/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="sv-SE">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Hämta uppdatering</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Ladda ner nya Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Den här uppdateringen innehåller mindre buggfixar, UI-justeringar och andra prestandaförbättringar.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Få hjälp</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Vi har släppt en uppdaterad version av Mozilla VPN! Uppdatera till den senaste versionen för bästa möjliga Mozilla VPN-upplevelse.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Uppdatera nu</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Uppdatering till Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/tr/addons/strings.xliff
+++ b/tr/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="tr">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Güncellemeyi indir</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Yeni Mozilla VPN %1 sürümünü indirin</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Bu güncellemede küçük hata düzeltmeleri, arayüz düzenlemeleri ve bazı performans iyileştirmeleri yaptık.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Yardım al</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Mozilla VPN’in yeni sürümü çıktı! En iyi Mozilla VPN deneyimi için en son sürüme güncelleyin.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Şimdi güncelle</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Mozilla VPN %1 sürümüne güncelleyin</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/uk/addons/strings.xliff
+++ b/uk/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="uk">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Завантажити оновлення</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Завантажити нову версію Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Це оновлення містить виправлення незначних помилок, покращення інтерфейсу користувача та інші вдосконалення швидкодії.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Отримати допомогу</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Ми випустили оновлену версію Mozilla VPN! Встановіть оновлення для якнайкращої роботи Mozilla VPN.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Оновити зараз</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Оновити до Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/vi/addons/strings.xliff
+++ b/vi/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="vi">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Tải xuống bản cập nhật</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>Tải xuống Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>Bản cập nhật này bao gồm các bản sửa lỗi nhỏ, điều chỉnh giao diện người dùng và cải tiến hiệu suất khác.</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Nhận trợ giúp</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>Chúng tôi đã phát hành bản cập nhật của Mozilla VPN! Cập nhật lên phiên bản mới nhất để có trải nghiệm Mozilla VPN tốt nhất có thể.</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>Cập nhật ngay</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>Cập nhật lên Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/zh_CN/addons/strings.xliff
+++ b/zh_CN/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="zh-CN">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>下载更新</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>下载新版 Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>此更新包含了次要问题修复、界面调整及其他性能改进。</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>获取帮助</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>我们发布了 Mozilla VPN 的更新版本！请升级到最新版本，享受最佳 Mozilla VPN 体验。</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>立即更新</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>更新至 Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>

--- a/zh_TW/addons/strings.xliff
+++ b/zh_TW/addons/strings.xliff
@@ -2,37 +2,37 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="addon.qml" datatype="plaintext" source-language="en" target-language="zh-TW">
     <body>
-      <trans-unit id="CommonStringsDownloadButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>下載更新</target>
         <source xml:space="preserve">Download update</source>
       </trans-unit>
-      <trans-unit id="CommonStringsDownloadTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.downloadTitle" xml:space="preserve">
         <note annotates="source" from="developer">Alternative title used for some versions. %1 is replaced by the version number, such as 2.24</note>
         <target>下載新版的 Mozilla VPN %1</target>
         <source xml:space="preserve">Download the new Mozilla VPN %1</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGeneralUpdateContent" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.generalUpdateContent" xml:space="preserve">
         <note annotates="source" from="developer">Default update notes</note>
         <target>此次更新修正了一些小錯誤、介面設計調整，以及效能改善。</target>
         <source xml:space="preserve">This update includes minor bug fixes, UI adjustments and other performance improvements.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsGetHelpButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.getHelpButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>取得幫助</target>
         <source xml:space="preserve">Get help</source>
       </trans-unit>
-      <trans-unit id="CommonStringsSubtitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.subtitle" xml:space="preserve">
         <note annotates="source" from="developer">Subtitle for default update message</note>
         <target>我們推出了新版本的 Mozilla VPN！請更新到最新版，即可獲得最佳的使用體驗。</target>
         <source xml:space="preserve">We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateButton" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateButton" xml:space="preserve">
         <note annotates="source" from="developer">Button label</note>
         <target>立即更新</target>
         <source xml:space="preserve">Update now</source>
       </trans-unit>
-      <trans-unit id="CommonStringsUpdateTitle" xml:space="preserve">
+      <trans-unit id="vpn.commonStrings.updateTitle" xml:space="preserve">
         <note annotates="source" from="developer">Title for update message. %1 is replaced by the version number, such as 2.24</note>
         <target>更新到 Mozilla VPN %1</target>
         <source xml:space="preserve">Update to Mozilla VPN %1</source>


### PR DESCRIPTION
## Description

The “shared addons strings” for VPN ([VPN PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9763/), [translations PR](https://github.com/mozilla-l10n/mozilla-vpn-client-l10n/pull/466)) had a bug - the string IDs in pontoon are of the form `CommonStringsSubtitle`, and the intention was `vpn.commonStrings.subtitle`. While this is non-standard (per the rest of our string IDs), it also provides an unlikely-but-real technical issue of a future clash - `update.soonMessage` and `updateSoon.message` from different parts of the YAML file would end up with the same ID of `CommonStringsUpdateSoonMessage`.

This PR updates the strings to the intended format.

### There is another PR on the client repo to update the script to this format: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10065

### The two PRs must be merged at the same time, so that the subsequent ingestion script run doesn't re-introduce the bad IDs and doesn't introduce the good IDs (without translations).

## Reference

VPN-6749
